### PR TITLE
fix: scope partition_config loads by hot_period (#14)

### DIFF
--- a/ci/journey.sh
+++ b/ci/journey.sh
@@ -1545,6 +1545,73 @@ EOF
 }
 
 # ───────────────────────────────────────────────────────────────────────────
+# Story — issue #14: coldfront.partition_config is ONE shared table holding both
+# archiver-owned (tiered: hot_period set) and partitioner-owned (partition-only:
+# hot_period NULL) rows. Each binary must load only the rows it owns, scoped in
+# SQL by hot_period. Pre-fix the shared loader took every enabled row, so the
+# archiver choked on the partition-only row ("hot_period is required in tiered
+# mode") and the partitioner on the tiered row ("only valid in tiered mode").
+# Mirrors the issue's repro: one of each in a private schema, run each binary,
+# assert it logs "loaded 1 table(s)" and the validation errors are absent. A
+# private schema keeps the p_YYYY_MM leaves clear of public.events (see
+# idmode_check) and the cleanup keeps the shared config clean for later stories.
+# ───────────────────────────────────────────────────────────────────────────
+story_partition_config_ownership() {
+    step "Shared partition_config: each binary loads only the rows it owns (issue #14)"
+    local dsn="host=${DB_IP} port=5432 dbname=coldfront user=coldfront password=coldfront sslmode=disable"
+    q "$HOST" "CREATE SCHEMA IF NOT EXISTS own;
+               CREATE TABLE IF NOT EXISTS own.po  (id bigint GENERATED ALWAYS AS IDENTITY, ts timestamptz NOT NULL, PRIMARY KEY (id, ts)) PARTITION BY RANGE (ts);
+               CREATE TABLE IF NOT EXISTS own.tier(id bigint GENERATED ALWAYS AS IDENTITY, ts timestamptz NOT NULL, PRIMARY KEY (id, ts)) PARTITION BY RANGE (ts);" >/dev/null
+
+    # own.po → partition-only (partitioner, hot_period NULL); own.tier → tiered
+    # (archiver, hot_period set). Both land in the one shared partition_config
+    # (which also still holds earlier stories' tiered rows: events, cli_events —
+    # so we assert per-table ownership, NOT an absolute "loaded N" count).
+    "$PARTITIONER" register --dsn "$dsn" --schema own --table po   --period monthly --retention "60 months" >/tmp/journey-own-po-reg.log   2>&1
+    "$ARCHIVER"    register --dsn "$dsn" --schema own --table tier --period monthly --hot-period "1 month" --retention "60 months" >/tmp/journey-own-tier-reg.log 2>&1
+    assert_eq "issue #14: partition-only row owned by partitioner (hot_period NULL)" "1" \
+        "$(q "$HOST" "SELECT count(*) FROM coldfront.partition_config WHERE schema_name='own' AND table_name='po'   AND hot_period IS NULL;")"
+    assert_eq "issue #14: tiered row owned by archiver (hot_period set)"             "1" \
+        "$(q "$HOST" "SELECT count(*) FROM coldfront.partition_config WHERE schema_name='own' AND table_name='tier' AND hot_period IS NOT NULL;")"
+
+    # Archiver run: processes its tiered row (own.tier), never the partitioner's
+    # partition-only row (own.po), and no longer aborts on a foreign row.
+    "$ARCHIVER" --config /tmp/journey-archiver.yaml >/tmp/journey-own-arch.log 2>&1 || true
+    if grep -q "hot_period is required in tiered mode" /tmp/journey-own-arch.log; then
+        fail "issue #14: archiver still choked on the partition-only row"; tail -5 /tmp/journey-own-arch.log
+    else
+        pass "issue #14: archiver did not choke on the partition-only row"
+    fi
+    # Per-table logs use the bare source-table name ([tier] / [po]); own.tier and
+    # own.po are unique here so the substrings are unambiguous.
+    assert_contains "issue #14: archiver processed its own tiered table" "[tier]" "$(cat /tmp/journey-own-arch.log)"
+    if grep -q "\[po\]" /tmp/journey-own-arch.log; then
+        fail "issue #14: archiver touched the partitioner's row (po)"; tail -5 /tmp/journey-own-arch.log
+    else
+        pass "issue #14: archiver ignored the partitioner's row (po)"
+    fi
+
+    # Partitioner run: reconciles its partition-only row (own.po), never the
+    # archiver's tiered row (own.tier), and no longer aborts on a foreign row.
+    printf 'postgres: { dsn: "%s" }\n' "$dsn" > /tmp/journey-own-part.yaml
+    "$PARTITIONER" --config /tmp/journey-own-part.yaml >/tmp/journey-own-part.log 2>&1 || true
+    if grep -q "only valid in tiered mode" /tmp/journey-own-part.log; then
+        fail "issue #14: partitioner still choked on the tiered row"; tail -5 /tmp/journey-own-part.log
+    else
+        pass "issue #14: partitioner did not choke on the tiered row"
+    fi
+    assert_contains "issue #14: partitioner reconciled its own partition-only table" "[po] reconciled" "$(cat /tmp/journey-own-part.log)"
+    if grep -q "\[tier\]" /tmp/journey-own-part.log; then
+        fail "issue #14: partitioner touched the archiver's row (tier)"; tail -5 /tmp/journey-own-part.log
+    else
+        pass "issue #14: partitioner ignored the archiver's row (tier)"
+    fi
+
+    # Clean up so the SHARED coldfront.partition_config stays clean for later stories.
+    q "$HOST" "DELETE FROM coldfront.partition_config WHERE schema_name='own'; DROP SCHEMA own CASCADE;" >/dev/null 2>&1
+}
+
+# ───────────────────────────────────────────────────────────────────────────
 # Story — Enterprise privilege model: a NON-superuser app role, onboarded with a
 # single coldfront.grant_app_access() call, reads AND writes the tiered view
 # transparently — no superuser, no pg_*_server_files, no per-session setup.
@@ -1614,6 +1681,7 @@ if [ "$MODE" = "tiered" ]; then
     story_partitioner_multitable
     story_partitioner_after_swap
     story_register_cli
+    story_partition_config_ownership   # issue #14: each binary loads only its own rows
 else
     story_provision_decoupled
     story_decoupled_crud

--- a/cmd/archiver/main.go
+++ b/cmd/archiver/main.go
@@ -121,7 +121,7 @@ func setupConnection(ctx context.Context, cfg *config.Config) (*pgx.Conn, *water
 func resolveAndValidateTables(ctx context.Context, cfg *config.Config, conn *pgx.Conn, configPath string) {
 	// Resolve managed tables from the replicated coldfront.partition_config
 	// table, falling back to the YAML archiver.tables (deprecation bridge).
-	tables, fromYAML, err := partcfg.ResolveTables(ctx, conn, cfg.Archiver.Tables)
+	tables, fromYAML, err := partcfg.ResolveTables(ctx, conn, cfg.Archiver.Tables, partcfg.Tiered)
 	if err != nil {
 		log.Fatalf("resolve tables: %v", err)
 	}

--- a/cmd/partitioner/main.go
+++ b/cmd/partitioner/main.go
@@ -108,7 +108,7 @@ func dispatchSubcommand(ctx context.Context) bool {
 func loadAndResolve(ctx context.Context, conn *pgx.Conn, cfg *config.Config, cfgPath string) {
 	// Resolve managed tables from the replicated coldfront.partition_config
 	// table, falling back to the YAML archiver.tables (deprecation bridge).
-	tables, fromYAML, err := partcfg.ResolveTables(ctx, conn, cfg.Archiver.Tables)
+	tables, fromYAML, err := partcfg.ResolveTables(ctx, conn, cfg.Archiver.Tables, partcfg.PartitionOnly)
 	if err != nil {
 		log.Fatalf("resolve tables: %v", err)
 	}

--- a/internal/partcfg/commands.go
+++ b/internal/partcfg/commands.go
@@ -790,7 +790,7 @@ EXAMPLES:
 	if err := EnsureTable(ctx, conn); err != nil {
 		return err
 	}
-	tables, err := LoadTables(ctx, conn)
+	tables, err := LoadTables(ctx, conn, AllOwners) // export is ownership-agnostic
 	if err != nil {
 		return err
 	}

--- a/internal/partcfg/partcfg.go
+++ b/internal/partcfg/partcfg.go
@@ -104,16 +104,29 @@ func EnsureTable(ctx context.Context, db DBTX) error {
 	return nil
 }
 
-// ResolveTables returns the managed-table set: it ensures the table exists,
-// then returns the partition_config rows if there are any, else the supplied
-// YAML fallback (the deprecation bridge for not-yet-migrated deployments). The
-// bool is true when the YAML fallback was used. Callers fail loud if the result
-// is empty (both sources empty).
-func ResolveTables(ctx context.Context, db DBTX, yamlFallback []config.TableConfig) ([]config.TableConfig, bool, error) {
+// owner selects which partition_config rows to load, by the hot_period mode
+// switch that already distinguishes the two binaries' tables: tiered rows
+// (hot_period set) belong to the archiver, partition-only rows (hot_period NULL)
+// to the partitioner. AllOwners is the ownership-agnostic path (export/list).
+// The int values are the $1 selector in LoadTables' SQL — do not reorder.
+type owner int
+
+const (
+	AllOwners     owner = iota // every enabled row (export, list)
+	Tiered                     // archiver    — hot_period IS NOT NULL
+	PartitionOnly              // partitioner — hot_period IS NULL
+)
+
+// ResolveTables returns the managed-table set the caller owns: it ensures the
+// table exists, then returns the partition_config rows matching own if there are
+// any, else the supplied YAML fallback (the deprecation bridge for not-yet-
+// migrated deployments). The bool is true when the YAML fallback was used.
+// Callers fail loud if the result is empty (both sources empty).
+func ResolveTables(ctx context.Context, db DBTX, yamlFallback []config.TableConfig, own owner) ([]config.TableConfig, bool, error) {
 	if err := EnsureTable(ctx, db); err != nil {
 		return nil, false, err
 	}
-	rows, err := LoadTables(ctx, db)
+	rows, err := LoadTables(ctx, db, own)
 	if err != nil {
 		return nil, false, err
 	}
@@ -123,16 +136,22 @@ func ResolveTables(ctx context.Context, db DBTX, yamlFallback []config.TableConf
 	return yamlFallback, true, nil
 }
 
-// LoadTables reads the enabled partition_config rows into the existing
-// config.TableConfig shape, so every downstream consumer is unchanged.
-func LoadTables(ctx context.Context, db DBTX) ([]config.TableConfig, error) {
+// LoadTables reads the enabled partition_config rows the caller owns into the
+// existing config.TableConfig shape, so every downstream consumer is unchanged.
+// own filters by the hot_period ownership switch (see owner); AllOwners loads all.
+func LoadTables(ctx context.Context, db DBTX, own owner) ([]config.TableConfig, error) {
 	rows, err := db.Query(ctx, `
 		SELECT schema_name, table_name, partition_period, partition_column,
 		       future_partitions, part_mode, id_scheme, hot_period::text,
 		       retention_period::text, sub_part_values_source, expiration_strategy
 		FROM coldfront.partition_config
 		WHERE enabled
-		ORDER BY schema_name, table_name`)
+		  AND CASE $1::int
+		        WHEN 1 THEN hot_period IS NOT NULL   -- Tiered (archiver)
+		        WHEN 2 THEN hot_period IS NULL       -- PartitionOnly (partitioner)
+		        ELSE true                            -- AllOwners
+		      END
+		ORDER BY schema_name, table_name`, int(own))
 	if err != nil {
 		return nil, fmt.Errorf("query partition_config: %w", err)
 	}

--- a/internal/partcfg/partcfg_test.go
+++ b/internal/partcfg/partcfg_test.go
@@ -31,15 +31,18 @@ func (r *mockRows) RawValues() [][]byte                          { return nil }
 func (r *mockRows) Conn() *pgx.Conn                              { return nil }
 
 type mockDB struct {
-	execSQL  []string
-	rowsFunc func() (pgx.Rows, error)
+	execSQL   []string
+	rowsFunc  func() (pgx.Rows, error)
+	querySQL  string // last Query SQL — lets tests assert the ownership filter
+	queryArgs []any  // last Query args — $1 is the owner selector
 }
 
 func (m *mockDB) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
 	m.execSQL = append(m.execSQL, sql)
 	return pgconn.NewCommandTag("OK"), nil
 }
-func (m *mockDB) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+func (m *mockDB) Query(_ context.Context, sql string, args ...any) (pgx.Rows, error) {
+	m.querySQL, m.queryArgs = sql, args
 	return m.rowsFunc()
 }
 
@@ -89,7 +92,8 @@ func TestResolveTables_DBWins(t *testing.T) {
 		}}, nil
 	}}
 	yaml := []config.TableConfig{{SourceTable: "from_yaml"}}
-	got, fromYAML, err := ResolveTables(context.Background(), db, yaml)
+	// The row is partition-only (hot NULL), so the partitioner owns it.
+	got, fromYAML, err := ResolveTables(context.Background(), db, yaml, PartitionOnly)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +108,7 @@ func TestResolveTables_DBWins(t *testing.T) {
 func TestResolveTables_YAMLFallback(t *testing.T) {
 	db := &mockDB{rowsFunc: emptyRows} // no partition_config rows
 	yaml := []config.TableConfig{{SourceTable: "from_yaml"}}
-	got, fromYAML, err := ResolveTables(context.Background(), db, yaml)
+	got, fromYAML, err := ResolveTables(context.Background(), db, yaml, PartitionOnly)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +152,7 @@ func TestLoadTables(t *testing.T) {
 		}}, nil
 	}}
 
-	got, err := LoadTables(context.Background(), db)
+	got, err := LoadTables(context.Background(), db, AllOwners)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,5 +180,51 @@ func TestLoadTables(t *testing.T) {
 	}
 	if b.HotPeriod != "" {
 		t.Fatalf("row 1 hot_period should be empty (partition-only), got %q", b.HotPeriod)
+	}
+}
+
+// TestLoadTables_PassesOwnerFilter pins issue #14: each binary must scope its
+// load by ownership. The mock ignores the WHERE clause itself, so we assert the
+// owner selector reaches the query as $1 (the real Postgres filter is proven
+// end-to-end in ci/journey.sh). int(owner): AllOwners=0, Tiered=1, PartitionOnly=2.
+func TestLoadTables_PassesOwnerFilter(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		own  owner
+		want int
+	}{
+		{"export loads all", AllOwners, 0},
+		{"archiver loads tiered", Tiered, 1},
+		{"partitioner loads partition-only", PartitionOnly, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := &mockDB{rowsFunc: emptyRows}
+			if _, err := LoadTables(context.Background(), db, tc.own); err != nil {
+				t.Fatal(err)
+			}
+			if len(db.queryArgs) != 1 {
+				t.Fatalf("expected 1 query arg (the owner selector), got %v", db.queryArgs)
+			}
+			if got, ok := db.queryArgs[0].(int); !ok || got != tc.want {
+				t.Fatalf("owner selector $1 = %v, want %d", db.queryArgs[0], tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveTables_NoRowsFallsBackToYAML — when the binary's filtered query
+// returns nothing (an empty table, or only rows owned by the other binary),
+// ResolveTables falls back to the deprecated YAML bridge, exactly as it does for
+// an empty table today. The filter runs in SQL, so an empty result is
+// indistinguishable from an empty table here.
+func TestResolveTables_NoRowsFallsBackToYAML(t *testing.T) {
+	db := &mockDB{rowsFunc: emptyRows}
+	yaml := []config.TableConfig{{SourceTable: "from_yaml"}}
+	got, fromYAML, err := ResolveTables(context.Background(), db, yaml, Tiered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fromYAML || len(got) != 1 || got[0].SourceTable != "from_yaml" {
+		t.Fatalf("expected YAML fallback when the filtered query is empty, got fromYAML=%v %+v", fromYAML, got)
 	}
 }


### PR DESCRIPTION
Each binary loads only the rows it owns: for archiver, `hot_period IS NOT NULL`, for partitioner, `hot_period IS NULL`, export all. Fixes #14.