### PR TITLE
build: auto-detect arch in duckdb base image (arm64)

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -13,33 +13,93 @@ name: Base image (DuckDB 1.5.x)
 # Trigger from the Actions tab (or `gh workflow run base-image.yml`) when the base
 # inputs change (Dockerfile.duckdb15-base / the iceberg patch / config). For an
 # initial publish, pushing a locally-built base is faster — see DUCKDB_1.5_PATCHED.md.
+#
+# The arch/pg inputs scope a single one-off build (e.g. an arm64 smoke test on a
+# native ubuntu-24.04-arm runner, free for public repos). Left at defaults it
+# builds all three PG majors for amd64. Smoke builds default to NO push.
 on:
   workflow_dispatch:
+    inputs:
+      arch:
+        description: 'Target arch'
+        type: choice
+        default: amd64
+        options: [amd64, arm64]
+      pg:
+        description: 'PG major (single), or "all" for 16/17/18'
+        type: choice
+        default: all
+        options: [all, '18', '17', '16']
+      push:
+        description: 'Push to GHCR (off for smoke tests)'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
   packages: write   # GITHUB_TOKEN pushes to ghcr.io/pgedge
 
 jobs:
-  base:
-    name: base pg${{ matrix.pg }}
+  # Resolve the dispatch inputs into a runner label and a PG-major matrix so the
+  # build job stays a plain matrix. amd64→ubuntu-latest, arm64→ubuntu-24.04-arm
+  # (native arm64, free for public repos — no QEMU). pg=all→[18,17,16].
+  setup:
     runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.r.outputs.runner }}
+      platform: ${{ steps.r.outputs.platform }}
+      pgs: ${{ steps.r.outputs.pgs }}
+    steps:
+      - id: r
+        run: |
+          set -euo pipefail
+          case "${{ inputs.arch }}" in
+            amd64) echo "runner=ubuntu-latest"   >> "$GITHUB_OUTPUT"
+                   echo "platform=linux/amd64"   >> "$GITHUB_OUTPUT" ;;
+            arm64) echo "runner=ubuntu-24.04-arm" >> "$GITHUB_OUTPUT"
+                   echo "platform=linux/arm64"   >> "$GITHUB_OUTPUT" ;;
+          esac
+          if [ "${{ inputs.pg }}" = "all" ]; then
+            echo 'pgs=["18","17","16"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'pgs=["${{ inputs.pg }}"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  base:
+    needs: setup
+    name: base pg${{ matrix.pg }} (${{ inputs.arch }})
+    runs-on: ${{ needs.setup.outputs.runner }}
     timeout-minutes: 300
     strategy:
       fail-fast: false
       matrix:
-        pg: ['18', '17', '16']
+        pg: ${{ fromJSON(needs.setup.outputs.pgs) }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      - name: Build + push base image
+      - name: Build base image (${{ needs.setup.outputs.platform }})
         run: |
           set -euo pipefail
-          IMG=ghcr.io/pgedge/coldfront-duckdb-base:pg${{ matrix.pg }}
-          docker build -f docker/Dockerfile.duckdb15-base --build-arg PG_MAJOR=${{ matrix.pg }} -t "$IMG" .
+          IMG=ghcr.io/pgedge/coldfront-duckdb-base:pg${{ matrix.pg }}-${{ inputs.arch }}
+          docker buildx build \
+            --platform ${{ needs.setup.outputs.platform }} \
+            -f docker/Dockerfile.duckdb15-base \
+            --build-arg PG_MAJOR=${{ matrix.pg }} \
+            -t "$IMG" \
+            --load .
+          echo "Built $IMG"
+
+      - name: Push base image
+        if: ${{ inputs.push }}
+        run: |
+          set -euo pipefail
+          IMG=ghcr.io/pgedge/coldfront-duckdb-base:pg${{ matrix.pg }}-${{ inputs.arch }}
           docker push "$IMG"
           echo "Pushed $IMG"

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin

--- a/docker/Dockerfile.duckdb15-base
+++ b/docker/Dockerfile.duckdb15-base
@@ -11,10 +11,30 @@
 # (.github/workflows/base-image.yml) builds and pushes it to
 # ghcr.io/pgedge/coldfront-duckdb-base with the workflow GITHUB_TOKEN.
 #
+# The image is arch-aware: it builds natively for the host arch (amd64 on x86_64,
+# arm64 on aarch64). The manylinux base, vcpkg triplet, and DuckDB extension dir
+# are all derived from the target arch — no manual edits to switch arches.
+#
+#   # native (host arch):
 #   docker build -f docker/Dockerfile.duckdb15-base --build-arg PG_MAJOR=18 \
 #       -t ghcr.io/pgedge/coldfront-duckdb-base:pg18 .
+#
+#   # cross-build arm64 under emulation on an x86_64 host (needs buildx + QEMU:
+#   #   docker run --privileged --rm tonistiigi/binfmt --install arm64):
+#   docker buildx build --platform linux/arm64 -f docker/Dockerfile.duckdb15-base \
+#       --build-arg PG_MAJOR=18 -t coldfront-duckdb-base:pg18-arm64 --load .
 ARG PG_MAJOR=18
 ARG PGEDGE_TAG=${PG_MAJOR}-spock5-minimal
+
+# Target arch, auto-detected by buildx (amd64 on x86_64 hosts, arm64 on aarch64).
+# TARGETARCH is a built-in buildx ARG, populated for free from --platform / the
+# build host. The iceberg-builder FROM needs the manylinux image suffix resolved
+# BEFORE the stage starts (FROM can't run shell), so the manylinux-resolve stage
+# below maps amd64→x86_64 / arm64→aarch64 and pins iceberg-builder's base to it.
+# The vcpkg triplet and the DuckDB platform string are derived from `uname -m`
+# inside their own RUN steps. Override --build-arg TARGETARCH=arm64 to
+# cross-build under emulation on an x86_64 host.
+ARG TARGETARCH=amd64
 
 # ─── build stage: libcurl 8.12 + pg_duckdb (DuckDB 1.5.3, PR #1025) ──────────────
 FROM ghcr.io/pgedge/pgedge-postgres:${PGEDGE_TAG} AS build
@@ -62,8 +82,17 @@ RUN printf '\noverride CXXFLAGS := $(filter-out -fexcess-precision=standard,$(CX
 RUN make -C /build/pg_duckdb -j"$(nproc)" with_llvm=no \
  && DESTDIR=/out make -C /build/pg_duckdb install with_llvm=no
 
+# ─── manylinux base selection (arch-resolved) ───────────────────────────────────
+# Alias each manylinux arch image, then pick one by TARGETARCH. This indirection
+# is needed because Dockerfile FROM cannot nest ARG expansion (no ${VAR_${VAR}});
+# the unused alias is never pulled or built.
+FROM --platform=linux/amd64 quay.io/pypa/manylinux_2_28_x86_64  AS manylinux-amd64
+FROM --platform=linux/arm64 quay.io/pypa/manylinux_2_28_aarch64 AS manylinux-arm64
+ARG TARGETARCH
+FROM manylinux-${TARGETARCH} AS manylinux-base
+
 # ─── iceberg-builder stage: iceberg + avro + azure (DuckDB 1.5.x ABI, PATCHED) ──
-FROM quay.io/pypa/manylinux_2_28_x86_64 AS iceberg-builder
+FROM manylinux-base AS iceberg-builder
 ARG ICEBERG_REF=0fad545a
 # libasan/libubsan: the extension_configuration phase builds a Debug
 # duckdb_platform_binary that links AddressSanitizer. perl-Time-Piece:
@@ -113,9 +142,17 @@ RUN cd /build/duckdb-iceberg \
  && git apply        /tmp/iceberg-mcontent-v15.patch \
  && git apply --check /tmp/iceberg-fileformat-v15.patch \
  && git apply        /tmp/iceberg-fileformat-v15.patch
+# vcpkg triplet is derived from the build arch (uname -m): x86_64→x64-linux,
+# aarch64→arm64-linux. Host and target match here (the stage runs on the target
+# arch, native or emulated), so HOST and TARGET triplets are the same value.
 RUN cd /build/duckdb-iceberg && bash -c 'source /opt/rh/gcc-toolset-*/enable 2>/dev/null; \
+    case "$(uname -m)" in \
+      x86_64)  VCPKG_TRIPLET=x64-linux ;; \
+      aarch64) VCPKG_TRIPLET=arm64-linux ;; \
+      *) echo "unsupported build arch: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
     export VCPKG_TOOLCHAIN_PATH=/build/vcpkg/scripts/buildsystems/vcpkg.cmake VCPKG_ROOT=/build/vcpkg \
-           VCPKG_TARGET_TRIPLET=x64-linux VCPKG_HOST_TRIPLET=x64-linux USE_MERGED_VCPKG_MANIFEST=1 \
+           VCPKG_TARGET_TRIPLET=$VCPKG_TRIPLET VCPKG_HOST_TRIPLET=$VCPKG_TRIPLET USE_MERGED_VCPKG_MANIFEST=1 \
            EXT_CONFIG=/build/duckdb-iceberg/extension_config.cmake OVERRIDE_GIT_DESCRIBE=v1.5.3 \
            CMAKE_BUILD_PARALLEL_LEVEL=$(nproc); \
     make -j$(nproc) release'
@@ -123,6 +160,7 @@ RUN cd /build/duckdb-iceberg && bash -c 'source /opt/rh/gcc-toolset-*/enable 2>/
 # ─── base runtime stage (pg_duckdb + iceberg, NO coldfront) ──────────────────────
 FROM ghcr.io/pgedge/pgedge-postgres:${PGEDGE_TAG}
 ARG PG_MAJOR
+ARG TARGETARCH
 USER root
 RUN dnf install -y --setopt=install_weak_deps=False --allowerasing \
         libcurl lz4 pgedge-postgresql${PG_MAJOR}-contrib openssl \
@@ -148,8 +186,11 @@ COPY --from=iceberg-builder /build/duckdb-iceberg/build/release/extension/azure/
 # postgres_scanner (the 'postgres' ext) — shipped so install_extension('postgres')
 # resolves it locally; the terrible-link runtime download is removed entirely.
 COPY --from=iceberg-builder /build/duckdb-iceberg/build/release/extension/postgres_scanner/postgres_scanner.duckdb_extension /opt/coldfront/iceberg/postgres_scanner.duckdb_extension
+# DuckDB's platform string is linux_<arch> with the SAME arch tokens buildx uses
+# (amd64/arm64), so the extension dir is just linux_${TARGETARCH}. The entrypoint
+# places the iceberg/avro/azure extensions under .../v1.5.3/$COLDFRONT_DUCKDB_PLATFORM.
 ENV COLDFRONT_DUCKDB_VERSION=v1.5.3 \
-    COLDFRONT_DUCKDB_PLATFORM=linux_amd64
+    COLDFRONT_DUCKDB_PLATFORM=linux_${TARGETARCH}
 
 COPY docker/entrypoint.sh /usr/local/bin/coldfront-entrypoint.sh
 RUN chmod +x /usr/local/bin/coldfront-entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -125,7 +125,15 @@ EOF
     # is on). The version/platform subpath is pinned in lockstep with the
     # iceberg-builder's OVERRIDE_GIT_DESCRIBE. See DUCKDB_1.5_PATCHED.md.
     if [ -f /opt/coldfront/iceberg/iceberg.duckdb_extension ]; then
-        EXTDIR="$PGDATA/pg_duckdb/extensions/${COLDFRONT_DUCKDB_VERSION:-v1.5.3}/${COLDFRONT_DUCKDB_PLATFORM:-linux_amd64}"
+        # COLDFRONT_DUCKDB_PLATFORM is baked into the image (linux_<arch>). The
+        # fallback derives it from the running arch so it never silently points at
+        # the wrong-arch dir: x86_64→linux_amd64, aarch64→linux_arm64.
+        case "$(uname -m)" in
+            x86_64)  _cf_default_platform=linux_amd64 ;;
+            aarch64) _cf_default_platform=linux_arm64 ;;
+            *)       _cf_default_platform="linux_$(uname -m)" ;;
+        esac
+        EXTDIR="$PGDATA/pg_duckdb/extensions/${COLDFRONT_DUCKDB_VERSION:-v1.5.3}/${COLDFRONT_DUCKDB_PLATFORM:-$_cf_default_platform}"
         mkdir -p "$EXTDIR"
         cp /opt/coldfront/iceberg/iceberg.duckdb_extension "$EXTDIR/iceberg.duckdb_extension"
         cp /opt/coldfront/iceberg/avro.duckdb_extension    "$EXTDIR/avro.duckdb_extension"


### PR DESCRIPTION
Base image picks manylinux/vcpkg triplet/platform from `TARGETARCH`; `base-image.yml` gains an arm64 build input (native `ubuntu-24.04-arm`). `pgedge-postgres` arm64 base present for PG 16/17/18.