### PR TITLE
fix: azure app-role extension load + compactor CI gap (#17)

### DIFF
--- a/ci/journey.sh
+++ b/ci/journey.sh
@@ -530,6 +530,17 @@ EOSQL
 }
 
 # ───────────────────────────────────────────────────────────────────────────
+# require_compactor — stories 6d/6e drive the standalone Go compactor (cmd/compactor,
+# a separate iceberg-go module). Assert its binary is present before they run: a missing
+# "$COMPACTOR" otherwise gets captured into the dry-run output as "No such file or
+# directory" and reported as "nothing to compact", masking the real cause (issue #17 —
+# 6d/6e ran against a vanilla.sh that never built the compactor).
+require_compactor() {
+    [ -x "$COMPACTOR" ] && return 0
+    fail "compactor binary not found/executable at $COMPACTOR — build it with 'make compactor'; stories 6d/6e require it"
+    return 1
+}
+
 # Story 6d — Compaction: the standalone Go compactor (cmd/compactor) consolidates
 # the cold tier's many small Parquet files into fewer large ones via
 # apache/iceberg-go RewriteDataFiles, serialized through the bakery (the SAME
@@ -547,6 +558,7 @@ story_compaction() {
     # defaulting to v1 and rejecting them at PlanFiles (manifest.go:629). This live
     # story validates that fix end-to-end.
     step "6d. Compaction: iceberg-go RewriteDataFiles consolidates small cold files (bakery-serialized)"
+    require_compactor || return
     qf "$HOST" <<'EOSQL'
 INSERT INTO events (ts, status, data) VALUES (date_trunc('month',now()) - interval '4 months' + interval '1 days' + interval '0 hours','cmp1','{}');
 INSERT INTO events (ts, status, data) VALUES (date_trunc('month',now()) - interval '4 months' + interval '1 days' + interval '1 hours','cmp2','{}');
@@ -592,6 +604,7 @@ EOSQL
 # ───────────────────────────────────────────────────────────────────────────
 story_maintenance() {
     step "6e. Maintenance: expire old snapshots + reclaim orphan files (iceberg-go, bakery-serialized)"
+    require_compactor || return
     local rows_before; rows_before=$(q "$HOST" "SELECT count(*) FROM events;")
 
     local snaps; snaps=$("$COMPACTOR" --config /tmp/journey-archiver.yaml --table events --expire-snapshots --dry-run 2>&1)

--- a/ci/topo/vanilla.sh
+++ b/ci/topo/vanilla.sh
@@ -153,6 +153,13 @@ fi
 step "vanilla: build archiver"
 make -s build >/dev/null 2>&1 || go build -o bin/archiver ./cmd/archiver
 
+# The compactor is a separate iceberg-go module that `make build` does NOT build.
+# Journey stories 6d/6e drive it; without it a missing ./bin/compactor read as a cryptic
+# "No such file or directory" and masked real compactor regressions (issue #17). Build it
+# here, and abort if the build fails since 6d/6e depend on it.
+step "vanilla: build compactor (separate iceberg-go module; journey 6d/6e need it)"
+make -s compactor || { echo "vanilla.sh: compactor build failed — stories 6d/6e require ./bin/compactor"; exit 1; }
+
 topo_standby "$DB"
 
 step "vanilla: run journey (backend=$BACKEND mode=$MODE standby=$STANDBY)"

--- a/extension/coldfront/coldfront--1.0.sql
+++ b/extension/coldfront/coldfront--1.0.sql
@@ -206,6 +206,13 @@ BEGIN
     -- Background: https://curl.se/docs/CVE-2025-0665.html
     -- Run AFTER the ATTACH (httpfs loaded); GLOBAL = this backend's instance; idempotent.
     PERFORM duckdb.raw_query($q$SET GLOBAL httpfs_client_implementation = 'httplib'$q$);
+    -- httpfs (s3) already loaded as a side-effect of the ATTACH above; azure does
+    -- not, so its lazy autoload would otherwise fire later as the non-superuser
+    -- app role and hit pg_duckdb's LocalFileSystem block (issue #17). Pre-load it
+    -- here, while still in this SECURITY DEFINER (elevated) context.
+    IF EXISTS (SELECT 1 FROM coldfront.storage_secret WHERE storage_type = 'azure') THEN
+      PERFORM duckdb.raw_query('LOAD azure');
+    END IF;
   END IF;
 END;
 -- SECURITY DEFINER: this must run elevated. pg_duckdb force-disables DuckDB's


### PR DESCRIPTION
`ensure_attached()` pre-loads `azure` in its SECURITY DEFINER context when an azure secret is set, so a non-superuser app role no longer hits pg_duckdb's LocalFileSystem block on first ADLS access (gated; s3/azure-less builds untouched). `ci/topo/vanilla.sh` now builds the compactor and `ci/journey.sh` guards 6d/6e against a missing `bin/compactor` (was skipping silently). Verified on real Azure ADLS; `run-ci-local.sh` green. Refs #17.
