### PR TITLE
test: cover #20/#21 partition-key UPDATE rejection (no _events leak)

### DIFF
--- a/ci/journey.sh
+++ b/ci/journey.sh
@@ -527,6 +527,16 @@ EOSQL
     # rows) rather than silently returning a partial/void result.
     local cr; cr=$(q_may "$HOST" "UPDATE events SET status='x' WHERE ts < date_trunc('month',now()) - interval '3 months' RETURNING id;")
     assert_err "cold-tier RETURNING rejected" "cold tier" "$cr"
+    # An UPDATE that assigns the partition column is rejected before any tier write,
+    # so a cross-cutoff move can't silently lose the row (#20) and a hot→archived-
+    # range move can't leak the internal _events partition-routing error (#21). Both
+    # directions error the same way regardless of which tier the WHERE selects.
+    local pkc; pkc=$(q_may "$HOST" "UPDATE events SET ts=date_trunc('month',now()) - interval '1 month' WHERE ts < date_trunc('month',now()) - interval '3 months';")
+    assert_err "partition-key UPDATE rejected (cold→hot, #20)" "partition column" "$pkc"
+    local pkh; pkh=$(q_may "$HOST" "UPDATE events SET ts=date_trunc('month',now()) - interval '4 months' WHERE status='dual_upd';")
+    assert_err "partition-key UPDATE rejected (hot→archived, #21)" "partition column" "$pkh"
+    # The #21 leak specifically: the internal _events name must NOT appear in the error.
+    case "$pkh" in *_events*) fail "#21: internal _events name leaked in error: $pkh";; *) pass "#21: internal _events name not leaked";; esac
 }
 
 # ───────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
#21 (hot row cross-tier `ts` update leaks the internal `_events` name) has the same root cause as #20 and is already fixed by partition-column block in #23. `UPDATE` is rejected at parse-analyze before the hot DML that hits PG partition router. Adds CI journey assertions for both directions plus explicit check that `_events` never appears in the error. Closes #21.