### PR TITLE
various fixes in the tiered-view DML rewrite path

### DIFF
--- a/ci/journey.sh
+++ b/ci/journey.sh
@@ -374,6 +374,13 @@ SELECT 'RO_COLD:'  || count(*) FROM events WHERE ts  < date_trunc('month',now())
 SELECT 'JSONB_TYPE:'   || pg_typeof(data)::text FROM events LIMIT 1;
 SELECT 'JSONB_COLD_M:' || (data->>'m') FROM events WHERE ts < date_trunc('month',now()) - interval '2 months' AND status='ok' ORDER BY ts LIMIT 1;
 SELECT 'JSONB_HOT_M:'  || (data->>'m') FROM events WHERE ts >= date_trunc('month',now()) - interval '2 months' AND status='ok' ORDER BY ts LIMIT 1;
+-- Read-path jsonb→json whitelist. The whole view query runs in DuckDB; the hook
+-- translates the ::jsonb cast (so an explicit cast does not hit DuckDB's missing
+-- jsonb type) and jsonb_array_length (verified identical in both engines). Cold and
+-- hot, on real Iceberg data.
+SELECT 'CAST_COLD:' || ((data::jsonb)->>'m') FROM events WHERE ts < date_trunc('month',now()) - interval '2 months' AND status='ok' ORDER BY ts LIMIT 1;
+SELECT 'CAST_HOT:'  || ((data::jsonb)->>'m') FROM events WHERE ts >= date_trunc('month',now()) - interval '2 months' AND status='ok' ORDER BY ts LIMIT 1;
+SELECT 'ALEN_COLD:' || jsonb_array_length('[10,20,30]'::jsonb) FROM events WHERE ts < date_trunc('month',now()) - interval '2 months' AND status='ok' ORDER BY ts LIMIT 1;
 EOSQL
 )
     assert_eq "total rows (hot+cold via view)" "280"  "$(extract RO_TOTAL "$O")"
@@ -382,6 +389,30 @@ EOSQL
     assert_eq "data surfaces as json" "json" "$(extract JSONB_TYPE "$O")"
     assert_eq "json cold round-trip"  "m4"  "$(extract JSONB_COLD_M "$O")"
     assert_eq "json hot round-trip"   "m2"  "$(extract JSONB_HOT_M "$O")"
+    assert_eq "::jsonb cast translated, cold" "m4" "$(extract CAST_COLD "$O")"
+    assert_eq "::jsonb cast translated, hot"  "m2" "$(extract CAST_HOT "$O")"
+    assert_eq "jsonb_array_length→json_array_length" "3" "$(extract ALEN_COLD "$O")"
+
+    # Hot-tier read routing: a read whose WHERE provably restricts to the hot tier
+    # (ts >= the watermark) is rewritten to the hot heap and runs in plain PostgreSQL,
+    # so jsonb operators/functions DuckDB lacks (jsonb_typeof, @>) work. m1..m4 all
+    # predate the watermark (date_trunc('month',now())), so insert a now() row (hot),
+    # exercise it, then delete it — the row counts asserted above stay intact.
+    qf "$HOST" >/dev/null <<'EOSQL'
+INSERT INTO events (ts, status, data) VALUES (now(), 'ok', '{"m":"hotjson","arr":[1,2,3]}'::jsonb);
+EOSQL
+    local HR; HR=$(qf "$HOST" <<'EOSQL'
+SELECT 'HOT_TYPEOF:'  || jsonb_typeof(data::jsonb)                         FROM events WHERE ts >= date_trunc('month',now()) AND data->>'m'='hotjson';
+SELECT 'HOT_CONTAIN:' || ((data::jsonb) @> '{"m":"hotjson"}'::jsonb)::text FROM events WHERE ts >= date_trunc('month',now()) AND data->>'m'='hotjson';
+SELECT 'HOT_HASKEY:' || ((data::jsonb) ? 'arr')::text                     FROM events WHERE ts >= date_trunc('month',now()) AND data->>'m'='hotjson';
+EOSQL
+)
+    qf "$HOST" >/dev/null <<'EOSQL'
+DELETE FROM events WHERE ts >= date_trunc('month',now()) AND data->>'m'='hotjson';
+EOSQL
+    assert_eq "hot read routes to PG: jsonb_typeof (DuckDB lacks it)"   "object" "$(extract HOT_TYPEOF "$HR")"
+    assert_eq "hot read routes to PG: @> containment (DuckDB lacks it)" "true"   "$(extract HOT_CONTAIN "$HR")"
+    assert_eq "hot read routes to PG: ? key-exists (DuckDB lacks it)"   "true"   "$(extract HOT_HASKEY "$HR")"
 }
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -465,9 +465,30 @@ table-creation time. We refuse silent fallback to `varchar` - losing
 precision/identity is worse than no support.
 
 `jsonb`, `json` and `interval` are stored as `varchar` in Iceberg (no
-native primitive) and view-cast back to the rich PG type on read. Queries
-like `data->>'key'` work; jsonb-only operators (`?`, `@>`) need an
-explicit `data::jsonb` cast.
+native primitive) and view-cast back to the rich PG type on read.
+Iceberg-backed reads run entirely in DuckDB, whose `json` type is the
+equivalent of PG's `jsonb`. Queries like `data->>'key'` and `data->'key'`
+work, and ColdFront translates the `::jsonb` cast and `jsonb_array_length`
+on read. The jsonb-only operators (`?`, `@>`, `<@`, `#>`, `#>>`) and most
+jsonb functions (`jsonb_typeof`, `jsonb_extract_path`,
+`jsonb_extract_path_text`, `jsonb_set`, `jsonb_path_*`, `jsonb_each`,
+`jsonb_object_keys`) are not supported on tiered or decoupled data:
+DuckDB either lacks them or its same-named function differs in signature
+or result. Reach into the document with `->`/`->>`.
+
+These limits apply only to reads that go through a tiered or
+iceberg-only view, which pg_duckdb plans entirely in DuckDB. Ordinary
+(non-tiered) PostgreSQL tables are untouched by ColdFront and keep full
+jsonb support, as does the hot partition table itself.
+
+A hot-only read is the exception. When a `SELECT` reads a tiered view
+directly (no join, CTE, or sub-query) and its `WHERE` provably restricts
+to the hot tier, ColdFront rewrites it to read the hot partition table in
+plain PostgreSQL: the full jsonb operator and function set works, and the
+query skips DuckDB entirely. Such a read surfaces `data` as native
+`jsonb` rather than the view's `json`. Reads that span tiers, are
+cold-only, or reach the view through a join or sub-query stay in DuckDB,
+where the limits above apply.
 
 `inet`/`cidr` are **not supported**: pg_duckdb cannot process PG `inet`
 (Oid 869) in any Iceberg-backed query, and every cross-tier read is
@@ -479,8 +500,11 @@ queries on the hot side only if needed).
 
 Keep the following caveats in mind when running either mode:
 
-- **`jsonb` reads**: surface as `json`, not `jsonb`. Most operators
-  work; the binary-only ones don't.
+- **`jsonb` reads**: surface as `json`. The `->`/`->>` operators work,
+  and ColdFront translates the `::jsonb` cast and `jsonb_array_length`;
+  other jsonb operators and functions are unsupported on cold or
+  cross-tier reads. A hot-only read of the view runs in PostgreSQL with
+  full jsonb (see Supported column types).
 - **Cross-tier isolation**: a long-running `SELECT` that touches the
   Iceberg side multiple times within one transaction may see writes from
   other sessions interleaved between scans. PG's repeatable-read does not

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -464,10 +464,11 @@ types, custom enums, arrays, composite types) is rejected at
 table-creation time. We refuse silent fallback to `varchar` - losing
 precision/identity is worse than no support.
 
-`jsonb`, `json` and `interval` are stored as `varchar` in Iceberg (no
-native primitive) and view-cast back to the rich PG type on read.
-Iceberg-backed reads run entirely in DuckDB, whose `json` type is the
-equivalent of PG's `jsonb`. Queries like `data->>'key'` and `data->'key'`
+`json`, `jsonb` and `interval` are stored as `varchar` in Iceberg (no
+native primitive). On read, `interval` is view-cast back to the rich PG
+type; `json` and `jsonb` surface as DuckDB's `json` (the equivalent of
+PG's `jsonb`), not the rich PG `jsonb` type, because Iceberg-backed reads
+run entirely in DuckDB. Queries like `data->>'key'` and `data->'key'`
 work, and ColdFront translates the `::jsonb` cast and `jsonb_array_length`
 on read. The jsonb-only operators (`?`, `@>`, `<@`, `#>`, `#>>`) and most
 jsonb functions (`jsonb_typeof`, `jsonb_extract_path`,

--- a/extension/coldfront/Makefile
+++ b/extension/coldfront/Makefile
@@ -17,7 +17,7 @@ REGRESS     = load_order update_unregistered_view update_heap_table \
               returning_literal_in_where cast_literal_in_value \
               classify_between_in_or allow_mixed_writes cold_write_batch_size_guc \
               dollar_quote_in_value mixed_case_identifier \
-              cast_in_dquoted_identifier \
+              cast_in_dquoted_identifier cast_normalize \
               ddl_noop_unregistered ddl_block_drop ddl_block_truncate \
               ddl_alter_column ddl_rename_table ddl_rename_view \
               ddl_partition_passthrough bakery_wraps_cold_writes \

--- a/extension/coldfront/Makefile
+++ b/extension/coldfront/Makefile
@@ -17,7 +17,7 @@ REGRESS     = load_order update_unregistered_view update_heap_table \
               returning_literal_in_where cast_literal_in_value \
               classify_between_in_or classify_now allow_mixed_writes cold_write_batch_size_guc \
               dollar_quote_in_value mixed_case_identifier \
-              cast_in_dquoted_identifier cast_normalize \
+              cast_in_dquoted_identifier cast_normalize bad_tablename \
               ddl_noop_unregistered ddl_block_drop ddl_block_truncate \
               ddl_alter_column ddl_rename_table ddl_rename_view \
               ddl_partition_passthrough bakery_wraps_cold_writes \

--- a/extension/coldfront/Makefile
+++ b/extension/coldfront/Makefile
@@ -17,7 +17,7 @@ REGRESS     = load_order update_unregistered_view update_heap_table \
               returning_literal_in_where cast_literal_in_value \
               classify_between_in_or classify_now allow_mixed_writes cold_write_batch_size_guc \
               dollar_quote_in_value mixed_case_identifier \
-              cast_in_dquoted_identifier cast_normalize bad_tablename \
+              cast_in_dquoted_identifier cast_normalize bad_tablename cte_on_dml cte_on_insert \
               ddl_noop_unregistered ddl_block_drop ddl_block_truncate \
               ddl_alter_column ddl_rename_table ddl_rename_view \
               ddl_partition_passthrough bakery_wraps_cold_writes \

--- a/extension/coldfront/Makefile
+++ b/extension/coldfront/Makefile
@@ -15,7 +15,7 @@ REGRESS     = load_order update_unregistered_view update_heap_table \
               update_hot_via_view update_cold_via_view update_ambiguous_rejected \
               update_partition_key_blocked \
               returning_literal_in_where cast_literal_in_value \
-              classify_between_in_or allow_mixed_writes cold_write_batch_size_guc \
+              classify_between_in_or classify_now allow_mixed_writes cold_write_batch_size_guc \
               dollar_quote_in_value mixed_case_identifier \
               cast_in_dquoted_identifier cast_normalize \
               ddl_noop_unregistered ddl_block_drop ddl_block_truncate \

--- a/extension/coldfront/src/coldfront.c
+++ b/extension/coldfront/src/coldfront.c
@@ -37,6 +37,7 @@
 #include "catalog/namespace.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_type_d.h"
+#include "executor/executor.h"
 #include "executor/spi.h"
 #include "lib/stringinfo.h"
 #include "nodes/parsenodes.h"
@@ -372,13 +373,73 @@ count_tiered_view_refs(Query *query, Oid view_oid)
 
 /* ---------- tier classification --------------------------------------- */
 
+/* True if `node` contains a Param or SubLink — neither can be evaluated as a
+ * standalone scalar, so eval_partition_bound declines such operands. */
+static bool
+bound_noneval_walker(Node *node, void *ctx)
+{
+    if (node == NULL)
+        return false;
+    if (IsA(node, Param) || IsA(node, SubLink))
+    {
+        *((bool *) ctx) = true;
+        return true;
+    }
+    return expression_tree_walker(node, bound_noneval_walker, ctx);
+}
+
+/*
+ * Resolve a partition-bound operand to a timestamptz value known at parse time.
+ * A literal Const yields its value directly. A non-Const operand is evaluated only
+ * when it is a self-contained, stable timestamptz expression — no Vars, params,
+ * sublinks, or volatile functions — so now()/CURRENT_* arithmetic (e.g.
+ * now() - interval '1 hour') folds to its transaction-fixed value and the
+ * predicate classifies to a single tier. Returns false (the caller treats it as
+ * TIER_AMBIGUOUS) for anything not pinnable now. timestamptz is pass-by-value, so
+ * the result outlives the throwaway executor state. The original expression stays
+ * in the Query for execution; only the tier decision reads this value.
+ */
+static bool
+eval_partition_bound(Node *node, TimestampTz *out)
+{
+    EState    *estate;
+    ExprState *exprstate;
+    Datum      d;
+    bool       isnull, bad = false;
+
+    if (IsA(node, Const))
+    {
+        Const *c = (Const *) node;
+        if (c->consttype != TIMESTAMPTZOID || c->constisnull)
+            return false;
+        *out = DatumGetTimestampTz(c->constvalue);
+        return true;
+    }
+
+    if (exprType(node) != TIMESTAMPTZOID || contain_var_clause(node) ||
+        contain_volatile_functions(node))
+        return false;
+    (void) bound_noneval_walker(node, &bad);
+    if (bad)
+        return false;
+
+    estate    = CreateExecutorState();
+    exprstate = ExecPrepareExpr((Expr *) node, estate);
+    d         = ExecEvalExprSwitchContext(exprstate,
+                                          GetPerTupleExprContext(estate), &isnull);
+    FreeExecutorState(estate);
+    if (isnull)
+        return false;
+    *out = DatumGetTimestampTz(d);
+    return true;
+}
+
 /*
  * Walk a qual node and return which tier the matching rows belong to.
  *
- * We handle direct comparisons of the partition column Var against a
- * timestamptz Const, and AND combinations thereof.  Anything else is
- * TIER_AMBIGUOUS — the hook errors on that rather than splitting a write
- * across tiers non-atomically.
+ * We handle direct comparisons of the partition column Var against a timestamptz
+ * value — a literal Const or a stable expression resolved by eval_partition_bound
+ * — and AND/OR combinations thereof.  Anything else is TIER_AMBIGUOUS.
  *
  * Tier boundary:  ts <  cutoff → cold,  ts >= cutoff → hot.
  */
@@ -387,9 +448,8 @@ classify_qual(Node *qual, Index result_rel, AttrNumber partcol_attno,
               TimestampTz cutoff)
 {
     OpExpr     *op;
-    Node       *a, *b;
+    Node       *a, *b, *other;
     Var        *var;
-    Const      *con;
     bool        var_left;
     char       *opname;
     TimestampTz val;
@@ -500,13 +560,13 @@ classify_qual(Node *qual, Index result_rel, AttrNumber partcol_attno,
     a = (Node *) linitial(op->args);
     b = (Node *) lsecond(op->args);
 
-    if (IsA(a, Var) && IsA(b, Const))
+    if (IsA(a, Var))
     {
-        var = (Var *) a; con = (Const *) b; var_left = true;
+        var = (Var *) a; other = b; var_left = true;
     }
-    else if (IsA(a, Const) && IsA(b, Var))
+    else if (IsA(b, Var))
     {
-        con = (Const *) a; var = (Var *) b; var_left = false;
+        var = (Var *) b; other = a; var_left = false;
     }
     else
         return TIER_AMBIGUOUS;
@@ -514,10 +574,13 @@ classify_qual(Node *qual, Index result_rel, AttrNumber partcol_attno,
     /* Only the partition column of the target relation matters */
     if ((Index) var->varno != result_rel || var->varattno != partcol_attno)
         return TIER_AMBIGUOUS;
-    if (con->consttype != TIMESTAMPTZOID || con->constisnull)
+
+    /* The bound must be a timestamptz value known now: a literal, or a stable
+     * expression (e.g. now() - interval '1 hour') we evaluate to its
+     * transaction-fixed value. Anything else stays TIER_AMBIGUOUS. */
+    if (!eval_partition_bound(other, &val))
         return TIER_AMBIGUOUS;
 
-    val    = DatumGetTimestampTz(con->constvalue);
     opname = get_opname(op->opno);
     if (!opname)
         return TIER_AMBIGUOUS;

--- a/extension/coldfront/src/coldfront.c
+++ b/extension/coldfront/src/coldfront.c
@@ -577,44 +577,38 @@ classify_tier(Query *query, TieredViewInfo *info)
 
 /* ---------- string helpers -------------------------------------------- */
 
+typedef struct { const char *pg; const char *duck; } CfSubst;
+
 /*
- * Rewrite PG-specific spellings in a deparsed SQL string into the
- * DuckDB-compatible equivalents that DuckDB will accept inside a
- * `duckdb.raw_query()` argument.  Two flavours of substitution:
- *
- *   1. Type casts.  PG's deparser emits "::timestamp with time zone",
- *      "::character varying", "::jsonb" etc., which DuckDB rejects.
- *      Map them to DuckDB's single-word names. `::jsonb` → `::json`
- *      because DuckDB has no jsonb type — coldfront's iceberg storage
- *      for jsonb columns is VARCHAR anyway, and the wrapper view casts
- *      back to json on read.
- *
- *   2. Function names.  PG's jsonb_* family doesn't exist in DuckDB,
- *      but the json_* family is the direct equivalent. Match the
- *      function name plus the opening "(" so a column or alias that
- *      happens to share a prefix doesn't false-match.
- *
- * Returns a palloc'd result. Quote-aware: skips substitution while
- * inside a single-quoted string literal or a double-quoted identifier,
- * so user text and identifiers are preserved verbatim. Embedded ''
- * and "" escapes inside a literal/identifier stay inside it.
+ * Cold-WRITE substitutions. The deparsed cold DML is handed to DuckDB inside a
+ * duckdb.raw_query() string, so DuckDB-only spellings are fine. Multi-word PG
+ * casts map to DuckDB's single-word names, and the boundary-aware jsonb→json
+ * catch-all (cf_apply_subst's jsonb_catchall arm) maps every other jsonb token —
+ * ::jsonb, jsonb_set, jsonb_extract_path, … — to its json_<rest> form. The few
+ * whose DuckDB name is not json_<rest> are listed here, matched with the opening
+ * paren so a column prefix can't false-match. A result DuckDB lacks (e.g.
+ * json_set) errors in DuckDB — its boundary, not a rewrite coldfront withholds.
+ */
+static const CfSubst cf_write_subst[] = {
+    { "::timestamp with time zone",    "::timestamptz" },
+    { "::timestamp without time zone", "::timestamp"   },
+    { "::character varying",           "::varchar"     },
+    { "::double precision",            "::double"      },
+    { "jsonb_build_object(",           "json_object("  },
+    { "jsonb_build_array(",            "json_array("   },
+    { "to_jsonb(",                     "to_json("      },
+};
+
+/*
+ * Rewrite a deparsed SQL string token-by-token using `map`, optionally followed by
+ * the boundary-aware jsonb→json catch-all. Returns a palloc'd result. Quote-aware:
+ * skips substitution inside a single-quoted literal or double-quoted identifier, so
+ * user text and identifiers are preserved verbatim; embedded '' and "" escapes stay
+ * inside their literal/identifier.
  */
 static char *
-normalize_casts_for_duckdb(const char *sql)
+cf_apply_subst(const char *sql, const CfSubst *map, int map_len, bool jsonb_catchall)
 {
-    static const struct { const char *pg; const char *duck; } map[] = {
-        /* type casts */
-        { "::timestamp with time zone",    "::timestamptz" },
-        { "::timestamp without time zone", "::timestamp"   },
-        { "::character varying",           "::varchar"     },
-        { "::double precision",            "::double"      },
-        { "::jsonb",                       "::json"        },
-        /* function-name spellings (matched with opening paren so a
-         * column/alias prefix can't false-match) */
-        { "jsonb_build_object(",           "json_object("  },
-        { "jsonb_build_array(",            "json_array("   },
-        { "to_jsonb(",                     "to_json("      },
-    };
     StringInfoData buf;
     const char    *p         = sql;
     bool           in_quote  = false;
@@ -658,12 +652,12 @@ normalize_casts_for_duckdb(const char *sql)
             continue;
         }
 
-        /* Outside any quotes: look for a PG cast spelling to normalise. */
+        /* Outside any quotes: look for a spelling to substitute. */
         if (!in_quote && !in_dquote)
         {
             bool replaced = false;
             int  i;
-            for (i = 0; i < (int) lengthof(map); i++)
+            for (i = 0; i < map_len; i++)
             {
                 size_t plen = strlen(map[i].pg); /* nosemgrep */
                 if (strncmp(p, map[i].pg, plen) == 0)
@@ -676,11 +670,40 @@ normalize_casts_for_duckdb(const char *sql)
             }
             if (replaced)
                 continue;
+
+            /* Catch-all jsonb → json at an identifier boundary: rewrite the
+             * `jsonb` token when it is preceded by a non-identifier char and not
+             * followed by a letter/digit, so the cast and jsonb_* function names
+             * map while an embedded identifier (my_jsonb_col) is left intact. */
+            if (jsonb_catchall && strncmp(p, "jsonb", 5) == 0) /* nosemgrep */
+            {
+                char prev = (p == sql) ? ' ' : p[-1];
+                char next = p[5];
+                bool prev_boundary =
+                    !((prev >= 'A' && prev <= 'Z') || (prev >= 'a' && prev <= 'z') ||
+                      (prev >= '0' && prev <= '9') || prev == '_');
+                bool next_ok =
+                    !((next >= 'A' && next <= 'Z') || (next >= 'a' && next <= 'z') ||
+                      (next >= '0' && next <= '9'));
+                if (prev_boundary && next_ok)
+                {
+                    appendStringInfoString(&buf, "json");
+                    p += 5;
+                    continue;
+                }
+            }
         }
 
         appendStringInfoChar(&buf, *p++);
     }
     return buf.data;
+}
+
+/* Cold-write path: full cast map + blanket jsonb→json (output goes to DuckDB). */
+static char *
+normalize_casts_for_duckdb(const char *sql)
+{
+    return cf_apply_subst(sql, cf_write_subst, lengthof(cf_write_subst), true);
 }
 
 /* ---------- SQL builder ----------------------------------------------- */

--- a/extension/coldfront/src/coldfront.c
+++ b/extension/coldfront/src/coldfront.c
@@ -1152,6 +1152,21 @@ collect_pg_source_relids(List *rtable, int result_rel_idx, List *acc)
     return acc;
 }
 
+/* Track single-quote string-literal state across a copied span: each ' toggles it.
+ * A '' escape toggles twice (net no change), and no replacement target can sit
+ * between the two quotes of '', so the state is exact at every match position.
+ * Lets prefix_pg_tables_with_pglocal leave occurrences inside string literals
+ * untouched while still rewriting double-quoted table identifiers. */
+static bool
+span_toggles_squote(const char *from, const char *to, bool in_squote)
+{
+    const char *c;
+    for (c = from; c < to; c++)
+        if (*c == '\'')
+            in_squote = !in_squote;
+    return in_squote;
+}
+
 static char *
 prefix_pg_tables_with_pglocal(Query *query, char *sql)
 {
@@ -1166,6 +1181,7 @@ prefix_pg_tables_with_pglocal(Query *query, char *sql)
         StringInfoData buf;
         const char    *p, *match;
         size_t         qlen, blen;
+        bool           in_squote;
         char          *bare = NULL;
         const char    *q_n, *q_ns;
 
@@ -1179,14 +1195,21 @@ prefix_pg_tables_with_pglocal(Query *query, char *sql)
             bare = pstrdup(q_n);
         }
 
-        /* Pass 1: replace qualified `<schema>.<table>` occurrences. */
+        /* Pass 1: replace qualified `<schema>.<table>` occurrences that fall
+         * outside any single-quoted string literal (a qualified name inside a
+         * literal is user data, not a table reference). */
         qlen = strlen(qualified); /* nosemgrep */
         initStringInfo(&buf);
         p = sql;
+        in_squote = false;
         while ((match = strstr(p, qualified)) != NULL)
         {
+            in_squote = span_toggles_squote(p, match, in_squote);
             appendBinaryStringInfo(&buf, p, match - p);
-            appendStringInfoString(&buf, replacement);
+            if (in_squote)
+                appendBinaryStringInfo(&buf, match, qlen);  /* inside a literal — leave verbatim */
+            else
+                appendStringInfoString(&buf, replacement);
             p = match + qlen;
         }
         appendStringInfoString(&buf, p);
@@ -1201,6 +1224,7 @@ prefix_pg_tables_with_pglocal(Query *query, char *sql)
         blen = strlen(bare); /* nosemgrep */
         initStringInfo(&buf);
         p = sql;
+        in_squote = false;
         while ((match = strstr(p, bare)) != NULL)
         {
             char before = (match == sql) ? ' ' : match[-1];
@@ -1217,8 +1241,9 @@ prefix_pg_tables_with_pglocal(Query *query, char *sql)
                   (after  >= '0' && after  <= '9') ||
                   after  == '_' || after  == '$' ||
                   after  == '"');
+            in_squote = span_toggles_squote(p, match, in_squote);
             appendBinaryStringInfo(&buf, p, match - p);
-            if (wb_before && wb_after)
+            if (!in_squote && wb_before && wb_after)
                 appendStringInfoString(&buf, replacement);
             else
                 appendBinaryStringInfo(&buf, match, blen);

--- a/extension/coldfront/src/coldfront.c
+++ b/extension/coldfront/src/coldfront.c
@@ -50,6 +50,7 @@
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
+#include "utils/regproc.h"
 #include "utils/ruleutils.h"
 #include "utils/timestamp.h"
 #include "fmgr.h"
@@ -663,6 +664,23 @@ static const CfSubst cf_write_subst[] = {
 };
 
 /*
+ * Tiered-READ substitutions. A rewritten SELECT is reparsed by PG and then planned
+ * by DuckDB, so a translation must be valid in BOTH engines — which rules out the
+ * write path's blanket catch-all. Only the jsonb type cast and the functions
+ * verified identical in PG and DuckDB are translated; every other jsonb spelling is
+ * left untouched, so DuckDB rejects it with a clear "… does not exist" (a documented
+ * read limitation). Blanket-mapping would break two ways: jsonb_path_query →
+ * json_path_query fails PG reparse (PG has no json_path_query), and
+ * json_extract_path_text / json_type are signature- or vocabulary-incompatible in
+ * DuckDB (array result; UBIGINT/VARCHAR vs number/string). json_array_length is
+ * verified identical ([10,20,30]→3, []→0) and exists in both.
+ */
+static const CfSubst cf_read_subst[] = {
+    { "::jsonb",             "::json"             },
+    { "jsonb_array_length(", "json_array_length(" },
+};
+
+/*
  * Rewrite a deparsed SQL string token-by-token using `map`, optionally followed by
  * the boundary-aware jsonb→json catch-all. Returns a palloc'd result. Quote-aware:
  * skips substitution inside a single-quoted literal or double-quoted identifier, so
@@ -767,6 +785,13 @@ static char *
 normalize_casts_for_duckdb(const char *sql)
 {
     return cf_apply_subst(sql, cf_write_subst, lengthof(cf_write_subst), true);
+}
+
+/* Tiered-read path: whitelist only (output is reparsed by PG, then run by DuckDB). */
+static char *
+normalize_jsonb_for_read(const char *sql)
+{
+    return cf_apply_subst(sql, cf_read_subst, lengthof(cf_read_subst), false);
 }
 
 /* ---------- SQL builder ----------------------------------------------- */
@@ -1970,19 +1995,124 @@ cf_reparse_and_replace(Query *query, const char *new_sql, ColdParamSet *ps)
 }
 
 /*
- * Read path: lazily attach 'ice' on the first SELECT in this session that
- * touches a registered tiered view, so the view body's iceberg_scan('ice...')
- * resolves — the version-agnostic cold-read attach (PG 16/17/18). Guarded
- * once-per-session; the relkind check inside query_reads_tiered_view keeps
- * plain queries off the SPI path.
+ * Hot-tier read routing. When a SELECT's WHERE provably restricts to the hot tier
+ * (classify_qual → TIER_HOT: the predicate proves ts >= cutoff, and cold rows all
+ * have ts < cutoff), the rows it can return are exactly those the hot heap already
+ * holds. Re-point the tiered-view reference at that heap and reparse: the read then
+ * runs in plain PostgreSQL — full jsonb, no DuckDB round-trip — instead of pg_duckdb
+ * planning the whole iceberg_scan UNION in DuckDB. The reparse re-resolves column
+ * types (the view casts data::json; the heap is native jsonb).
+ *
+ * Conservative by construction — only the simple single-relation shape (no join, CTE,
+ * set-op, sub-link, or row-mark) and only a proven-HOT predicate reroute; anything
+ * spanning tiers or ambiguous keeps the view, so cold rows can never be dropped.
+ * Returns true if it rerouted (and replaced *query in place).
+ */
+static bool
+cf_try_reroute_hot_read(Query *query)
+{
+    RangeTblEntry *view_rte;
+    TieredViewInfo info;
+    AttrNumber     partcol_attno;
+    Oid            hot_oid;
+    char           hot_relkind;
+    Node          *quals;
+    Query         *clone;
+    RangeTblEntry *crte;
+    char          *sql;
+    ColdParamSet   ps;
+    RangeVar      *rv;
+    List          *names;
+
+    if (query->cteList || query->setOperations || query->hasSubLinks ||
+        query->rowMarks || list_length(query->rtable) != 1)
+        return false;
+
+    view_rte = (RangeTblEntry *) linitial(query->rtable);
+    if (view_rte->rtekind != RTE_RELATION ||
+        get_rel_relkind(view_rte->relid) != RELKIND_VIEW)
+        return false;
+    if (!lookup_tiered_view(view_rte->relid, get_rel_name(view_rte->relid), &info))
+        return false;
+    if (info.is_iceberg_only || !info.hot_table || !info.partition_col ||
+        !info.has_cutoff)
+        return false;
+
+    /* The predicate must prove the read touches only the hot tier. */
+    partcol_attno = get_attnum(view_rte->relid, info.partition_col);
+    if (partcol_attno == InvalidAttrNumber)
+        return false;
+    quals = (query->jointree) ? query->jointree->quals : NULL;
+    if (classify_qual(quals, 1, partcol_attno, info.cutoff) != TIER_HOT)
+        return false;
+
+    /* Resolve the hot heap (relname is a ready-to-use, possibly-quoted SQL name). */
+    names = stringToQualifiedNameList(info.hot_table
+#if PG_VERSION_NUM >= 160000
+                                      , NULL
+#endif
+                                      );
+    rv          = makeRangeVarFromNameList(names);
+    hot_oid     = RangeVarGetRelid(rv, NoLock, true);
+    hot_relkind = OidIsValid(hot_oid) ? get_rel_relkind(hot_oid) : '\0';
+    if (hot_relkind != RELKIND_RELATION && hot_relkind != RELKIND_PARTITIONED_TABLE)
+        return false;
+
+    /* Re-point the relation at the heap, deparse, and reparse in place so column
+     * types re-resolve and the query plans in plain PG. */
+    clone = copyObject(query);
+    crte  = (RangeTblEntry *) linitial(clone->rtable);
+    crte->relid       = hot_oid;
+    crte->relkind     = hot_relkind;
+    crte->rellockmode = AccessShareLock;
+    sql = pg_get_querydef(clone, false);
+
+    collect_cold_params(query, &ps);
+    cf_reparse_and_replace(query, sql, &ps);
+    return true;
+}
+
+/*
+ * jsonb → json on the read path. A query against a tiered / iceberg-only view runs
+ * entirely in DuckDB (the view body is an iceberg_scan UNION), and DuckDB has no
+ * jsonb type. Deparse, apply the read whitelist (normalize_jsonb_for_read: the
+ * ::jsonb cast and the functions verified equivalent in both engines), reparse in
+ * place. No whitelisted token ⇒ strcmp matches and the query is left untouched (the
+ * common case — ->>/-> operators and plain reads never reparse). jsonb spellings
+ * outside the whitelist pass through and DuckDB rejects them clearly (documented).
+ */
+static void
+cf_normalize_read_jsonb(Query *query)
+{
+    char         *sql  = pg_get_querydef(query, false);
+    char         *norm = normalize_jsonb_for_read(sql);
+    ColdParamSet  ps;
+
+    if (strcmp(sql, norm) == 0)  /* nosemgrep */
+        return;
+    collect_cold_params(query, &ps);
+    cf_reparse_and_replace(query, norm, &ps);
+}
+
+/*
+ * Read path for a SELECT that touches a registered tiered view. First try to
+ * reroute a provably-hot read to the heap (runs in plain PG). Otherwise the read
+ * spans the cold tier: lazily attach 'ice' (once per session) so the view body's
+ * iceberg_scan('ice...') resolves — the version-agnostic cold-read attach (PG
+ * 16/17/18) — and normalize the whitelisted jsonb spellings so DuckDB (which runs
+ * the whole view query) accepts them. The relkind check inside
+ * query_reads_tiered_view keeps plain queries off the SPI path.
  */
 static void
 cf_maybe_attach_for_read(Query *query)
 {
-    if (query->commandType == CMD_SELECT &&
-        !coldfront_ice_attached &&
-        query_reads_tiered_view(query))
+    if (query->commandType != CMD_SELECT || !query_reads_tiered_view(query))
+        return;
+    if (cf_try_reroute_hot_read(query))
+        return;   /* rewritten to the hot heap; runs in plain PostgreSQL */
+    if (!coldfront_ice_attached)
         ensure_ice_attached_once();
+    cf_normalize_read_jsonb(query);
 }
 
 /*

--- a/extension/coldfront/src/coldfront.c
+++ b/extension/coldfront/src/coldfront.c
@@ -32,6 +32,8 @@
 
 #include "postgres.h"
 
+#include <ctype.h>
+
 #include "access/attnum.h"
 #include "access/xact.h"
 #include "catalog/namespace.h"
@@ -760,13 +762,10 @@ cf_apply_subst(const char *sql, const CfSubst *map, int map_len, bool jsonb_catc
             {
                 char prev = (p == sql) ? ' ' : p[-1];
                 char next = p[5];
-                bool prev_boundary =
-                    !((prev >= 'A' && prev <= 'Z') || (prev >= 'a' && prev <= 'z') ||
-                      (prev >= '0' && prev <= '9') || prev == '_');
-                bool next_ok =
-                    !((next >= 'A' && next <= 'Z') || (next >= 'a' && next <= 'z') ||
-                      (next >= '0' && next <= '9'));
-                if (prev_boundary && next_ok)
+                /* left edge not part of an identifier; right edge not a letter/
+                 * digit ('_' allowed, so jsonb_set maps to json_set). */
+                if (!(isalnum((unsigned char) prev) || prev == '_') &&
+                    !isalnum((unsigned char) next))
                 {
                     appendStringInfoString(&buf, "json");
                     p += 5;

--- a/extension/coldfront/src/coldfront.c
+++ b/extension/coldfront/src/coldfront.c
@@ -809,27 +809,49 @@ normalize_jsonb_for_read(const char *sql)
  */
 typedef struct {
     char       *orig_sql;   /* normalised, leading-whitespace-stripped */
+    size_t      head_len;   /* bytes before the verb: a leading WITH clause, else 0 */
     const char *rest;       /* points into orig_sql, past the prefix   */
-    const char *verb;       /* "UPDATE " or "DELETE FROM "             */
+    const char *verb;       /* "UPDATE " / "DELETE FROM " / "INSERT INTO " */
 } DeparseResult;
 
 /*
- * Run the deparsed-DML prefix-match ladder: try the unqualified prefix first,
- * then the schema-qualified one. Returns the matched prefix, or elogs the same
- * ERROR as before on no match.
+ * Locate the "VERB <relation> " prefix in the deparsed DML: the first occurrence
+ * outside any single-quoted string literal. A leading WITH clause puts the verb
+ * past offset 0, so this scans rather than anchoring at the start; the bytes
+ * before the match are that WITH preamble, which the builders carry through
+ * verbatim. cf_reject_multi_reference guarantees the result relation is named
+ * once, so the first out-of-literal hit is the statement's own target. Only one
+ * of the unqualified / schema-qualified spellings can match (the deparser emits
+ * one form). Returns the match start and sets *matched to the spelling found;
+ * elogs if neither is present.
  */
 static const char *
 find_dml_prefix(const char *orig_sql, const char *search_unqual,
-                const char *search_qual, const char *vname)
+                const char *search_qual, const char *vname,
+                const char **matched)
 {
-    if (strncmp(orig_sql, search_unqual, strlen(search_unqual)) == 0) /* nosemgrep */
-        return search_unqual;
-    else if (strncmp(orig_sql, search_qual, strlen(search_qual)) == 0) /* nosemgrep */
-        return search_qual;
+    size_t      lu = strlen(search_unqual); /* nosemgrep */
+    size_t      lq = strlen(search_qual);   /* nosemgrep */
+    const char *p;
+    bool        in_squote = false;
+
+    for (p = orig_sql; *p; p++)
+    {
+        if (*p == '\'')
+        {
+            in_squote = !in_squote;
+            continue;
+        }
+        if (in_squote)
+            continue;
+        if (strncmp(p, search_unqual, lu) == 0) { *matched = search_unqual; return p; } /* nosemgrep */
+        if (strncmp(p, search_qual,   lq) == 0) { *matched = search_qual;   return p; } /* nosemgrep */
+    }
 
     elog(ERROR,
-         "coldfront: cannot locate result relation \"%s\" at start of "
-         "deparsed DML: %s", vname, orig_sql);
+         "coldfront: cannot locate result relation \"%s\" in deparsed DML: %s",
+         vname, orig_sql);
+    *matched = NULL;
     return NULL; /* unreachable */
 }
 
@@ -839,7 +861,7 @@ deparse_and_find_prefix(Query *query, DeparseResult *dr)
     RangeTblEntry *rte;
     char          *vname, *ns;
     char           search_unqual[256], search_qual[256];
-    const char    *old_prefix;
+    const char    *matched, *at;
 
     dr->orig_sql = pg_get_querydef(query, false);
     {
@@ -883,9 +905,10 @@ deparse_and_find_prefix(Query *query, DeparseResult *dr)
         }
     }
 
-    old_prefix = find_dml_prefix(dr->orig_sql, search_unqual, search_qual, vname);
+    at = find_dml_prefix(dr->orig_sql, search_unqual, search_qual, vname, &matched);
 
-    dr->rest = dr->orig_sql + strlen(old_prefix); /* nosemgrep */
+    dr->head_len = (size_t) (at - dr->orig_sql);
+    dr->rest     = at + strlen(matched); /* nosemgrep */
 }
 
 /*
@@ -896,6 +919,7 @@ build_hot_dml(DeparseResult *dr, TieredViewInfo *info)
 {
     StringInfoData buf;
     initStringInfo(&buf);
+    appendBinaryStringInfo(&buf, dr->orig_sql, dr->head_len);  /* leading WITH, if any */
     appendStringInfo(&buf, "%s%s %s", dr->verb, info->hot_table, dr->rest);
     return buf.data;
 }
@@ -911,6 +935,7 @@ build_cold_dml(DeparseResult *dr, TieredViewInfo *info)
 {
     StringInfoData buf;
     initStringInfo(&buf);
+    appendBinaryStringInfo(&buf, dr->orig_sql, dr->head_len);  /* leading WITH, if any */
     appendStringInfo(&buf, "%s%s %s", dr->verb, info->iceberg_table, dr->rest);
     return normalize_casts_for_duckdb(buf.data);
 }
@@ -920,9 +945,8 @@ build_cold_dml(DeparseResult *dr, TieredViewInfo *info)
  * coldfront._exec_iceberg_with_claim(table, sql) — or _tiered_insert_cold's
  * source — receives.
  *
- * With no bound params (maxid==0) it is a plain quoted literal — BYTE-IDENTICAL
- * to the old behaviour, so the top-level/literal path is unchanged. With params
- * it is a format(<template>, $1, $2, ...) call: each out-of-literal $N becomes a
+ * With no bound params (maxid==0) it is a plain quoted literal. With params it
+ * is a format(<template>, $1, $2, ...) call: each out-of-literal $N becomes a
  * positional %P$L spec and stays LIVE as a format() arg, so PG binds the value
  * at execution and DuckDB only ever sees a finished literal. That is what lets
  * cold DML carry plpgsql / PREPARE / extended-protocol $N (Cause 1).
@@ -1798,6 +1822,19 @@ emit_tiered_insert(Query *query, TieredViewInfo *info, ColdParamSet *ps, bool in
     col_list   = insert_targetlist_collist(query);
     source     = skip_leading_collist(dr.rest);
     cutoff_lit = format_timestamptz_literal(info->cutoff);
+
+    /* A leading WITH clause (dr.head_len bytes, before "INSERT INTO <view> ") must
+     * reach both halves, which each read `source` inside a parenthesised derived
+     * table. Fold it into source so its CTEs scope to that subquery on each engine
+     * (PG hot, DuckDB cold) — no top-level WITH to merge. */
+    if (dr.head_len > 0)
+    {
+        StringInfoData sb;
+        initStringInfo(&sb);
+        appendBinaryStringInfo(&sb, dr.orig_sql, dr.head_len);
+        appendStringInfoString(&sb, source);
+        source = sb.data;
+    }
 
     {
         RangeTblEntry *rte = (RangeTblEntry *) list_nth(query->rtable,

--- a/extension/coldfront/test/expected/bad_tablename.out
+++ b/extension/coldfront/test/expected/bad_tablename.out
@@ -1,0 +1,43 @@
+-- Regression guard for the cold-tier INSERT … SELECT rewrite (pglocal prefixing):
+-- when a source-table name also appears as text inside a string literal, the
+-- prefixing step must rewrite ONLY the real FROM reference, never the occurrence
+-- inside the literal. Source table "Bad Tablename" is spelled so its quoted
+-- identifier appears verbatim inside a column literal below.
+-- White-box: EXPLAIN VERBOSE shows the rewritten cold SQL; we do NOT execute
+-- (no Iceberg attached under pg_regress — see update_cold_via_view.sql).
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+NOTICE:  extension "pg_duckdb" already exists, skipping
+CREATE EXTENSION IF NOT EXISTS coldfront;
+NOTICE:  extension "coldfront" already exists, skipping
+SET TIME ZONE 'UTC';
+-- White-box: checks the hook's SQL, not Iceberg I/O. Real cold I/O is ci/journey.sh.
+SET coldfront.warehouse = '';
+SET coldfront.lakekeeper_endpoint = '';
+SET coldfront.local_pg_dsn = '';
+-- iceberg-only view: every DML routes to the cold tier. A real backing table keeps
+-- the view auto-updatable; the hook rewrites the INSERT before the rewriter ever
+-- consults the view body.
+CREATE TABLE public._ice_base (id int, ts timestamptz, note text);
+CREATE VIEW public.iceonly AS SELECT * FROM public._ice_base;
+INSERT INTO coldfront.tiered_views(schema_name, relname, iceberg_table, is_iceberg_only)
+VALUES ('public', 'iceonly', 'ice.default.iceonly', true);
+-- Source table whose quoted name ("Bad Tablename") is embedded in the literal below.
+CREATE TABLE public."Bad Tablename" (id int, ts timestamptz, note text);
+-- The cold INSERT … SELECT streams source rows into Iceberg via pglocal. The FROM
+-- reference must become pglocal.public."Bad Tablename"; the string literal
+-- 'imported from "Bad Tablename"' must be left byte-for-byte intact.
+EXPLAIN (COSTS OFF, VERBOSE)
+  INSERT INTO public.iceonly
+  SELECT id, ts, 'imported from "Bad Tablename"' FROM public."Bad Tablename";
+                                                                                                                                                   QUERY PLAN                                                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   Output: _exec_iceberg_with_claim('ice.default.iceonly'::text, 'INSERT INTO ice.default.iceonly (id, ts, note)  SELECT pglocal.public."Bad Tablename".id,             pglocal.public."Bad Tablename".ts,             ''imported from "Bad Tablename"''            FROM pglocal.public."Bad Tablename"'::text)
+(2 rows)
+
+-- Cleanup. Unregister before dropping: the DDL hook blocks DROP of a registered
+-- tiered relation.
+DELETE FROM coldfront.tiered_views;
+DROP VIEW public.iceonly;
+DROP TABLE public._ice_base;
+DROP TABLE public."Bad Tablename";

--- a/extension/coldfront/test/expected/cast_normalize.out
+++ b/extension/coldfront/test/expected/cast_normalize.out
@@ -1,0 +1,86 @@
+-- Parity / drift guard for normalize_casts_for_duckdb. Two halves:
+--   (A) white-box: a cold UPDATE whose casts + jsonb functions exercise the
+--       normalizer; EXPLAIN VERBOSE shows the rewritten cold SQL carries the DuckDB
+--       spellings (::timestamp/::varchar/::double, json_object/json_set, ::json),
+--       the timestamptz bound, and the evt_jsonb identifier left intact.
+--   (B) parity: DuckDB itself rejects `jsonb` (so ::jsonb→::json is required) but
+--       accepts the rewrite targets. If a future DuckDB changes what it accepts,
+--       or a new storage type needs a rewrite, this surfaces it.
+-- White-box: we do NOT exercise Iceberg I/O.
+-- Suppress NOTICEs: raw_query echoes each DuckDB result as a (version-dependent)
+-- NOTICE, and CREATE EXTENSION emits "already exists" depending on suite order.
+SET client_min_messages = warning;
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+CREATE EXTENSION IF NOT EXISTS coldfront;
+SET TIME ZONE 'UTC';
+SET coldfront.warehouse = '';
+SET coldfront.lakekeeper_endpoint = '';
+-- evt_jsonb's name embeds "jsonb": it must survive the jsonb→json rewrite intact.
+CREATE TABLE public._events (id int, ts timestamptz, c_tsn timestamp,
+                             c_vc varchar, c_dp double precision, evt_jsonb jsonb);
+CREATE VIEW public.events AS SELECT * FROM public._events;
+INSERT INTO coldfront.tiered_views(schema_name, relname, hot_table, iceberg_table, partition_col)
+VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
+INSERT INTO coldfront.archive_watermark(table_name, cutoff_time)
+VALUES ('events', '2026-03-01'::timestamptz);
+-- (A) Cold UPDATE (ts < cutoff): the deparsed cold SQL must carry DuckDB spellings.
+-- Casts: timestamp without time zone → timestamp, character varying → varchar,
+-- double precision → double; the timestamptz bound stays timestamptz. jsonb → json
+-- everywhere: ::jsonb → ::json, jsonb_set → json_set, jsonb_build_object →
+-- json_object — but the column name evt_jsonb (jsonb embedded) is left intact.
+EXPLAIN (COSTS OFF, VERBOSE)
+  UPDATE public.events
+  SET c_tsn     = '2020-06-01 00:00:00'::timestamp without time zone,
+      c_vc      = 'x'::character varying,
+      c_dp      = 1.5::double precision,
+      evt_jsonb = jsonb_set(jsonb_build_object('k', 1), '{x}', '"v"'::jsonb)
+  WHERE ts < '2019-01-01'::timestamp with time zone;
+                                                                                                                                                                  QUERY PLAN                                                                                                                                                                  
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   Output: _exec_iceberg_with_claim('ice.default.events'::text, 'UPDATE ice.default.events SET c_tsn = ''Mon Jun 01 00:00:00 2020''::timestamp, c_vc = ''x''::varchar, c_dp = (1.5)::double, evt_jsonb = json_set(json_object(''k'', 1), ''{x}''::text[], ''"v"''::json)   WHERE (ts < ''Tue Jan 01 00:00:00 2019 UTC''::timestamptz)'::text)
+(2 rows)
+
+-- (B) Parity against the live DuckDB: the rewrite targets are accepted; `jsonb`
+-- is rejected (which is why the map rewrites it). A void row = accepted.
+SELECT duckdb.raw_query($$ SELECT NULL::json $$);
+ raw_query 
+-----------
+ 
+(1 row)
+
+SELECT duckdb.raw_query($$ SELECT json_object('k', 1) $$);
+ raw_query 
+-----------
+ 
+(1 row)
+
+SELECT duckdb.raw_query($$ SELECT NULL::timestamp $$);
+ raw_query 
+-----------
+ 
+(1 row)
+
+SELECT duckdb.raw_query($$ SELECT NULL::varchar $$);
+ raw_query 
+-----------
+ 
+(1 row)
+
+SELECT duckdb.raw_query($$ SELECT NULL::double $$);
+ raw_query 
+-----------
+ 
+(1 row)
+
+SELECT duckdb.raw_query($$ SELECT NULL::jsonb $$);
+ERROR:  (PGDuckDB/pgduckdb_raw_query_cpp) Catalog Error: Type with name jsonb does not exist!
+Did you mean "blob"?
+
+LINE 1:  SELECT NULL::jsonb 
+                      ^
+-- Cleanup.
+DELETE FROM coldfront.tiered_views;
+DELETE FROM coldfront.archive_watermark;
+DROP VIEW public.events;
+DROP TABLE public._events;

--- a/extension/coldfront/test/expected/classify_now.out
+++ b/extension/coldfront/test/expected/classify_now.out
@@ -1,0 +1,50 @@
+-- Regression guard: a tier predicate against a STABLE now()-relative expression
+-- (e.g. ts < now() - interval) is folded to its transaction-fixed value for tier
+-- classification, so it resolves to a single tier instead of forcing a dual write.
+-- A VOLATILE bound (clock_timestamp()) is NOT folded and stays ambiguous.
+-- allow_mixed_writes = off makes the ambiguous case a clean error. White-box.
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+NOTICE:  extension "pg_duckdb" already exists, skipping
+CREATE EXTENSION IF NOT EXISTS coldfront;
+NOTICE:  extension "coldfront" already exists, skipping
+SET TIME ZONE 'UTC';
+SET coldfront.warehouse = '';
+SET coldfront.lakekeeper_endpoint = '';
+SET coldfront.allow_mixed_writes = off;
+CREATE TABLE public._events (id int, ts timestamptz, status text);
+CREATE VIEW public.events AS SELECT * FROM public._events;
+INSERT INTO coldfront.tiered_views(schema_name, relname, hot_table, iceberg_table, partition_col)
+VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
+INSERT INTO coldfront.archive_watermark(table_name, cutoff_time)
+VALUES ('events', '2026-03-01'::timestamptz);
+-- Stable, far in the past (< cutoff) → COLD: rewritten to a single cold _exec,
+-- NOT a dual write. The original now()-expression is preserved for execution.
+EXPLAIN (COSTS OFF, VERBOSE)
+  UPDATE public.events SET status = 'x' WHERE ts < now() - interval '100 years';
+                                                                                  QUERY PLAN                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   Output: _exec_iceberg_with_claim('ice.default.events'::text, 'UPDATE ice.default.events SET status = ''x''::text   WHERE (ts < (now() - ''@ 100 years''::interval))'::text)
+(2 rows)
+
+-- Stable, recent (>= cutoff) → HOT: rewritten to a plain UPDATE on the hot heap.
+-- (ts < now() - '1 hour' would instead span both tiers → ambiguous, correctly.)
+EXPLAIN (COSTS OFF, VERBOSE)
+  UPDATE public.events SET status = 'x' WHERE ts >= now() - interval '1 hour';
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Update on public._events
+   ->  Seq Scan on public._events
+         Output: 'x'::text, ctid
+         Filter: (_events.ts >= (now() - '@ 1 hour'::interval))
+(4 rows)
+
+-- Volatile bound → not folded → AMBIGUOUS → clean rejection (mixed writes off).
+UPDATE public.events SET status = 'x' WHERE ts < clock_timestamp();
+ERROR:  UPDATE/DELETE on tiered view "events" must include a WHERE condition on "ts" that targets one tier
+HINT:  Use "ts >= <value>" for hot-tier writes, "ts < <value>" for cold-tier writes, or set coldfront.allow_mixed_writes = on to permit a non-atomic dual-tier rewrite.
+-- Cleanup.
+DELETE FROM coldfront.tiered_views;
+DELETE FROM coldfront.archive_watermark;
+DROP VIEW public.events;
+DROP TABLE public._events;

--- a/extension/coldfront/test/expected/cte_on_dml.out
+++ b/extension/coldfront/test/expected/cte_on_dml.out
@@ -1,0 +1,46 @@
+-- Regression guard: a leading WITH (CTE) clause on UPDATE/DELETE over a tiered
+-- view. pg_get_querydef emits the WITH clause before the verb, so the rewrite
+-- must find the result relation past the WITH preamble and carry the WITH through
+-- verbatim with only the relation swapped (hot heap / Iceberg). White-box:
+-- EXPLAIN VERBOSE shows the rewritten cold SQL; we do NOT execute.
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+NOTICE:  extension "pg_duckdb" already exists, skipping
+CREATE EXTENSION IF NOT EXISTS coldfront;
+NOTICE:  extension "coldfront" already exists, skipping
+SET TIME ZONE 'UTC';
+SET coldfront.warehouse = '';
+SET coldfront.lakekeeper_endpoint = '';
+CREATE TABLE public._events (id int, ts timestamptz, status text);
+CREATE VIEW public.events AS SELECT * FROM public._events;
+INSERT INTO coldfront.tiered_views(schema_name, relname, hot_table, iceberg_table, partition_col)
+VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
+INSERT INTO coldfront.archive_watermark(table_name, cutoff_time)
+VALUES ('events', '2026-03-01'::timestamptz);
+-- Cold UPDATE (ts < cutoff) with a CTE referenced in SET: the WITH must be
+-- carried into the cold DML with the relation swapped to ice.default.events.
+EXPLAIN (COSTS OFF, VERBOSE)
+  WITH v AS (SELECT 'cold_upd'::text AS s)
+  UPDATE public.events SET status = (SELECT s FROM v)
+  WHERE ts < '2026-01-01 00:00:00+00';
+                                                                                                                                 QUERY PLAN                                                                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   Output: _exec_iceberg_with_claim('ice.default.events'::text, 'WITH v AS (          SELECT ''cold_upd''::text AS s         )  UPDATE ice.default.events SET status = ( SELECT v.s            FROM v)   WHERE (ts < ''Thu Jan 01 00:00:00 2026 UTC''::timestamptz)'::text)
+(2 rows)
+
+-- Cold DELETE (ts < cutoff) with a CTE referenced in WHERE: WITH carried through.
+EXPLAIN (COSTS OFF, VERBOSE)
+  WITH lim AS (SELECT 99 AS n)
+  DELETE FROM public.events
+  WHERE ts < '2026-01-01 00:00:00+00' AND id < (SELECT n FROM lim);
+                                                                                                                              QUERY PLAN                                                                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   Output: _exec_iceberg_with_claim('ice.default.events'::text, 'WITH lim AS (          SELECT 99 AS n         )  DELETE FROM ice.default.events   WHERE ((ts < ''Thu Jan 01 00:00:00 2026 UTC''::timestamptz) AND (id < ( SELECT lim.n            FROM lim)))'::text)
+(2 rows)
+
+-- Cleanup.
+DELETE FROM coldfront.tiered_views;
+DELETE FROM coldfront.archive_watermark;
+DROP VIEW public.events;
+DROP TABLE public._events;

--- a/extension/coldfront/test/expected/cte_on_insert.out
+++ b/extension/coldfront/test/expected/cte_on_insert.out
@@ -1,0 +1,53 @@
+-- Regression guard: a leading WITH (CTE) clause on INSERT into a tiered view.
+-- emit_tiered_insert splits the row source across the PG hot half and the DuckDB
+-- cold half; the CTE must reach both. The rewrite folds the WITH into the source
+-- subquery so its CTEs scope to the derived table on each engine. White-box:
+-- EXPLAIN VERBOSE shows the rewritten split; we do NOT execute.
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+NOTICE:  extension "pg_duckdb" already exists, skipping
+CREATE EXTENSION IF NOT EXISTS coldfront;
+NOTICE:  extension "coldfront" already exists, skipping
+SET TIME ZONE 'UTC';
+SET coldfront.warehouse = '';
+SET coldfront.lakekeeper_endpoint = '';
+SET coldfront.local_pg_dsn = '';
+CREATE TABLE public._events (id int, ts timestamptz, status text);
+CREATE VIEW public.events AS SELECT * FROM public._events;
+INSERT INTO coldfront.tiered_views(schema_name, relname, hot_table, iceberg_table, partition_col)
+VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
+INSERT INTO coldfront.archive_watermark(table_name, cutoff_time)
+VALUES ('events', '2026-03-01'::timestamptz);
+-- INSERT ... SELECT FROM a CTE into the tiered view: the WITH must reach both the
+-- hot (PG) and cold (DuckDB) halves, folded into the source derived table.
+EXPLAIN (COSTS OFF, VERBOSE)
+  WITH s AS (SELECT 7 AS id, '2026-05-01 00:00:00+00'::timestamptz AS ts, 'new' AS status)
+  INSERT INTO public.events SELECT id, ts, status FROM s;
+                                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                                            
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   Output: (InitPlan 3).col1, (InitPlan 4).col1
+   CTE hot_ins
+     ->  Insert on public._events
+           Output: 1
+           ->  Result
+                 Output: 7, 'Fri May 01 00:00:00 2026 UTC'::timestamp with time zone, 'new'::text
+   CTE cold_call
+     ->  Result
+           Output: _exec_iceberg_with_claim('ice.default.events'::text, 'INSERT INTO ice.default.events SELECT id, ts, status FROM (WITH s AS (          SELECT 7 AS id,             ''Fri May 01 00:00:00 2026 UTC''::timestamptz AS ts,             ''new''::text AS status         )  SELECT s.id,             s.ts,             s.status            FROM s) AS coldfront_src(id, ts, status) WHERE ts < ''Sun Mar 01 00:00:00 2026 UTC''::timestamptz'::text)
+   InitPlan 3
+     ->  Aggregate
+           Output: count(*)
+           ->  CTE Scan on hot_ins
+                 Output: hot_ins."?column?"
+   InitPlan 4
+     ->  Aggregate
+           Output: count(*)
+           ->  CTE Scan on cold_call
+                 Output: cold_call._exec_iceberg_with_claim
+(20 rows)
+
+-- Cleanup.
+DELETE FROM coldfront.tiered_views;
+DELETE FROM coldfront.archive_watermark;
+DROP VIEW public.events;
+DROP TABLE public._events;

--- a/extension/coldfront/test/sql/bad_tablename.sql
+++ b/extension/coldfront/test/sql/bad_tablename.sql
@@ -1,0 +1,41 @@
+-- Regression guard for the cold-tier INSERT … SELECT rewrite (pglocal prefixing):
+-- when a source-table name also appears as text inside a string literal, the
+-- prefixing step must rewrite ONLY the real FROM reference, never the occurrence
+-- inside the literal. Source table "Bad Tablename" is spelled so its quoted
+-- identifier appears verbatim inside a column literal below.
+-- White-box: EXPLAIN VERBOSE shows the rewritten cold SQL; we do NOT execute
+-- (no Iceberg attached under pg_regress — see update_cold_via_view.sql).
+
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+CREATE EXTENSION IF NOT EXISTS coldfront;
+
+SET TIME ZONE 'UTC';
+-- White-box: checks the hook's SQL, not Iceberg I/O. Real cold I/O is ci/journey.sh.
+SET coldfront.warehouse = '';
+SET coldfront.lakekeeper_endpoint = '';
+SET coldfront.local_pg_dsn = '';
+
+-- iceberg-only view: every DML routes to the cold tier. A real backing table keeps
+-- the view auto-updatable; the hook rewrites the INSERT before the rewriter ever
+-- consults the view body.
+CREATE TABLE public._ice_base (id int, ts timestamptz, note text);
+CREATE VIEW public.iceonly AS SELECT * FROM public._ice_base;
+INSERT INTO coldfront.tiered_views(schema_name, relname, iceberg_table, is_iceberg_only)
+VALUES ('public', 'iceonly', 'ice.default.iceonly', true);
+
+-- Source table whose quoted name ("Bad Tablename") is embedded in the literal below.
+CREATE TABLE public."Bad Tablename" (id int, ts timestamptz, note text);
+
+-- The cold INSERT … SELECT streams source rows into Iceberg via pglocal. The FROM
+-- reference must become pglocal.public."Bad Tablename"; the string literal
+-- 'imported from "Bad Tablename"' must be left byte-for-byte intact.
+EXPLAIN (COSTS OFF, VERBOSE)
+  INSERT INTO public.iceonly
+  SELECT id, ts, 'imported from "Bad Tablename"' FROM public."Bad Tablename";
+
+-- Cleanup. Unregister before dropping: the DDL hook blocks DROP of a registered
+-- tiered relation.
+DELETE FROM coldfront.tiered_views;
+DROP VIEW public.iceonly;
+DROP TABLE public._ice_base;
+DROP TABLE public."Bad Tablename";

--- a/extension/coldfront/test/sql/cast_normalize.sql
+++ b/extension/coldfront/test/sql/cast_normalize.sql
@@ -1,0 +1,56 @@
+-- Parity / drift guard for normalize_casts_for_duckdb. Two halves:
+--   (A) white-box: a cold UPDATE whose casts + jsonb functions exercise the
+--       normalizer; EXPLAIN VERBOSE shows the rewritten cold SQL carries the DuckDB
+--       spellings (::timestamp/::varchar/::double, json_object/json_set, ::json),
+--       the timestamptz bound, and the evt_jsonb identifier left intact.
+--   (B) parity: DuckDB itself rejects `jsonb` (so ::jsonb→::json is required) but
+--       accepts the rewrite targets. If a future DuckDB changes what it accepts,
+--       or a new storage type needs a rewrite, this surfaces it.
+-- White-box: we do NOT exercise Iceberg I/O.
+
+-- Suppress NOTICEs: raw_query echoes each DuckDB result as a (version-dependent)
+-- NOTICE, and CREATE EXTENSION emits "already exists" depending on suite order.
+SET client_min_messages = warning;
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+CREATE EXTENSION IF NOT EXISTS coldfront;
+
+SET TIME ZONE 'UTC';
+SET coldfront.warehouse = '';
+SET coldfront.lakekeeper_endpoint = '';
+
+-- evt_jsonb's name embeds "jsonb": it must survive the jsonb→json rewrite intact.
+CREATE TABLE public._events (id int, ts timestamptz, c_tsn timestamp,
+                             c_vc varchar, c_dp double precision, evt_jsonb jsonb);
+CREATE VIEW public.events AS SELECT * FROM public._events;
+INSERT INTO coldfront.tiered_views(schema_name, relname, hot_table, iceberg_table, partition_col)
+VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
+INSERT INTO coldfront.archive_watermark(table_name, cutoff_time)
+VALUES ('events', '2026-03-01'::timestamptz);
+
+-- (A) Cold UPDATE (ts < cutoff): the deparsed cold SQL must carry DuckDB spellings.
+-- Casts: timestamp without time zone → timestamp, character varying → varchar,
+-- double precision → double; the timestamptz bound stays timestamptz. jsonb → json
+-- everywhere: ::jsonb → ::json, jsonb_set → json_set, jsonb_build_object →
+-- json_object — but the column name evt_jsonb (jsonb embedded) is left intact.
+EXPLAIN (COSTS OFF, VERBOSE)
+  UPDATE public.events
+  SET c_tsn     = '2020-06-01 00:00:00'::timestamp without time zone,
+      c_vc      = 'x'::character varying,
+      c_dp      = 1.5::double precision,
+      evt_jsonb = jsonb_set(jsonb_build_object('k', 1), '{x}', '"v"'::jsonb)
+  WHERE ts < '2019-01-01'::timestamp with time zone;
+
+-- (B) Parity against the live DuckDB: the rewrite targets are accepted; `jsonb`
+-- is rejected (which is why the map rewrites it). A void row = accepted.
+SELECT duckdb.raw_query($$ SELECT NULL::json $$);
+SELECT duckdb.raw_query($$ SELECT json_object('k', 1) $$);
+SELECT duckdb.raw_query($$ SELECT NULL::timestamp $$);
+SELECT duckdb.raw_query($$ SELECT NULL::varchar $$);
+SELECT duckdb.raw_query($$ SELECT NULL::double $$);
+SELECT duckdb.raw_query($$ SELECT NULL::jsonb $$);
+
+-- Cleanup.
+DELETE FROM coldfront.tiered_views;
+DELETE FROM coldfront.archive_watermark;
+DROP VIEW public.events;
+DROP TABLE public._events;

--- a/extension/coldfront/test/sql/classify_now.sql
+++ b/extension/coldfront/test/sql/classify_now.sql
@@ -1,0 +1,39 @@
+-- Regression guard: a tier predicate against a STABLE now()-relative expression
+-- (e.g. ts < now() - interval) is folded to its transaction-fixed value for tier
+-- classification, so it resolves to a single tier instead of forcing a dual write.
+-- A VOLATILE bound (clock_timestamp()) is NOT folded and stays ambiguous.
+-- allow_mixed_writes = off makes the ambiguous case a clean error. White-box.
+
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+CREATE EXTENSION IF NOT EXISTS coldfront;
+
+SET TIME ZONE 'UTC';
+SET coldfront.warehouse = '';
+SET coldfront.lakekeeper_endpoint = '';
+SET coldfront.allow_mixed_writes = off;
+
+CREATE TABLE public._events (id int, ts timestamptz, status text);
+CREATE VIEW public.events AS SELECT * FROM public._events;
+INSERT INTO coldfront.tiered_views(schema_name, relname, hot_table, iceberg_table, partition_col)
+VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
+INSERT INTO coldfront.archive_watermark(table_name, cutoff_time)
+VALUES ('events', '2026-03-01'::timestamptz);
+
+-- Stable, far in the past (< cutoff) → COLD: rewritten to a single cold _exec,
+-- NOT a dual write. The original now()-expression is preserved for execution.
+EXPLAIN (COSTS OFF, VERBOSE)
+  UPDATE public.events SET status = 'x' WHERE ts < now() - interval '100 years';
+
+-- Stable, recent (>= cutoff) → HOT: rewritten to a plain UPDATE on the hot heap.
+-- (ts < now() - '1 hour' would instead span both tiers → ambiguous, correctly.)
+EXPLAIN (COSTS OFF, VERBOSE)
+  UPDATE public.events SET status = 'x' WHERE ts >= now() - interval '1 hour';
+
+-- Volatile bound → not folded → AMBIGUOUS → clean rejection (mixed writes off).
+UPDATE public.events SET status = 'x' WHERE ts < clock_timestamp();
+
+-- Cleanup.
+DELETE FROM coldfront.tiered_views;
+DELETE FROM coldfront.archive_watermark;
+DROP VIEW public.events;
+DROP TABLE public._events;

--- a/extension/coldfront/test/sql/cte_on_dml.sql
+++ b/extension/coldfront/test/sql/cte_on_dml.sql
@@ -1,0 +1,38 @@
+-- Regression guard: a leading WITH (CTE) clause on UPDATE/DELETE over a tiered
+-- view. pg_get_querydef emits the WITH clause before the verb, so the rewrite
+-- must find the result relation past the WITH preamble and carry the WITH through
+-- verbatim with only the relation swapped (hot heap / Iceberg). White-box:
+-- EXPLAIN VERBOSE shows the rewritten cold SQL; we do NOT execute.
+
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+CREATE EXTENSION IF NOT EXISTS coldfront;
+
+SET TIME ZONE 'UTC';
+SET coldfront.warehouse = '';
+SET coldfront.lakekeeper_endpoint = '';
+
+CREATE TABLE public._events (id int, ts timestamptz, status text);
+CREATE VIEW public.events AS SELECT * FROM public._events;
+INSERT INTO coldfront.tiered_views(schema_name, relname, hot_table, iceberg_table, partition_col)
+VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
+INSERT INTO coldfront.archive_watermark(table_name, cutoff_time)
+VALUES ('events', '2026-03-01'::timestamptz);
+
+-- Cold UPDATE (ts < cutoff) with a CTE referenced in SET: the WITH must be
+-- carried into the cold DML with the relation swapped to ice.default.events.
+EXPLAIN (COSTS OFF, VERBOSE)
+  WITH v AS (SELECT 'cold_upd'::text AS s)
+  UPDATE public.events SET status = (SELECT s FROM v)
+  WHERE ts < '2026-01-01 00:00:00+00';
+
+-- Cold DELETE (ts < cutoff) with a CTE referenced in WHERE: WITH carried through.
+EXPLAIN (COSTS OFF, VERBOSE)
+  WITH lim AS (SELECT 99 AS n)
+  DELETE FROM public.events
+  WHERE ts < '2026-01-01 00:00:00+00' AND id < (SELECT n FROM lim);
+
+-- Cleanup.
+DELETE FROM coldfront.tiered_views;
+DELETE FROM coldfront.archive_watermark;
+DROP VIEW public.events;
+DROP TABLE public._events;

--- a/extension/coldfront/test/sql/cte_on_insert.sql
+++ b/extension/coldfront/test/sql/cte_on_insert.sql
@@ -1,0 +1,32 @@
+-- Regression guard: a leading WITH (CTE) clause on INSERT into a tiered view.
+-- emit_tiered_insert splits the row source across the PG hot half and the DuckDB
+-- cold half; the CTE must reach both. The rewrite folds the WITH into the source
+-- subquery so its CTEs scope to the derived table on each engine. White-box:
+-- EXPLAIN VERBOSE shows the rewritten split; we do NOT execute.
+
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+CREATE EXTENSION IF NOT EXISTS coldfront;
+
+SET TIME ZONE 'UTC';
+SET coldfront.warehouse = '';
+SET coldfront.lakekeeper_endpoint = '';
+SET coldfront.local_pg_dsn = '';
+
+CREATE TABLE public._events (id int, ts timestamptz, status text);
+CREATE VIEW public.events AS SELECT * FROM public._events;
+INSERT INTO coldfront.tiered_views(schema_name, relname, hot_table, iceberg_table, partition_col)
+VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
+INSERT INTO coldfront.archive_watermark(table_name, cutoff_time)
+VALUES ('events', '2026-03-01'::timestamptz);
+
+-- INSERT ... SELECT FROM a CTE into the tiered view: the WITH must reach both the
+-- hot (PG) and cold (DuckDB) halves, folded into the source derived table.
+EXPLAIN (COSTS OFF, VERBOSE)
+  WITH s AS (SELECT 7 AS id, '2026-05-01 00:00:00+00'::timestamptz AS ts, 'new' AS status)
+  INSERT INTO public.events SELECT id, ts, status FROM s;
+
+-- Cleanup.
+DELETE FROM coldfront.tiered_views;
+DELETE FROM coldfront.archive_watermark;
+DROP VIEW public.events;
+DROP TABLE public._events;


### PR DESCRIPTION
Six fixes in the tiered-view DML rewrite path, each with a test:

- jsonb spellings translated to DuckDB `json` on cold writes and tiered reads; provably-hot reads route to Postgres (`cast_normalize`, `story_reads`).
- now()-based tier predicates classify to one tier, not a dual-tier write (`classify_now`).
- pglocal prefixing no longer corrupts table names inside string literals (`bad_tablename`).
- `WITH` (CTE) UPDATE/DELETE/INSERT now rewrite correctly (`cte_on_dml`, `cte_on_insert`).
