### PR TITLE
relocate rows across tiers on a partition-column UPDATE (#20/#21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@
 - Explicit error handling, no panic
 - No speculative abstractions, no backwards-compatibility shims for scenarios that can't happen, no hypothetical-future configurability
 - Don't hardcode lists that can be derived at runtime (e.g. column names from pg_catalog). Every hardcoded value is a future bug.
+- Comments document only the CURRENT code — never changelog narration ("previously", "used to", "this changed", "now does", "FIX:"). History lives in git, not in the source.
 
 ## Working Style
 - Before making changes that span multiple files, mentally trace the FULL end-to-end path: data origin → what the code does with it → where it lands → how the query pipeline sees it

--- a/ci/journey.sh
+++ b/ci/journey.sh
@@ -558,16 +558,72 @@ EOSQL
     # rows) rather than silently returning a partial/void result.
     local cr; cr=$(q_may "$HOST" "UPDATE events SET status='x' WHERE ts < date_trunc('month',now()) - interval '3 months' RETURNING id;")
     assert_err "cold-tier RETURNING rejected" "cold tier" "$cr"
-    # An UPDATE that assigns the partition column is rejected before any tier write,
-    # so a cross-cutoff move can't silently lose the row (#20) and a hot→archived-
-    # range move can't leak the internal _events partition-routing error (#21). Both
-    # directions error the same way regardless of which tier the WHERE selects.
-    local pkc; pkc=$(q_may "$HOST" "UPDATE events SET ts=date_trunc('month',now()) - interval '1 month' WHERE ts < date_trunc('month',now()) - interval '3 months';")
-    assert_err "partition-key UPDATE rejected (cold→hot, #20)" "partition column" "$pkc"
-    local pkh; pkh=$(q_may "$HOST" "UPDATE events SET ts=date_trunc('month',now()) - interval '4 months' WHERE status='dual_upd';")
-    assert_err "partition-key UPDATE rejected (hot→archived, #21)" "partition column" "$pkh"
-    # The #21 leak specifically: the internal _events name must NOT appear in the error.
-    case "$pkh" in *_events*) fail "#21: internal _events name leaked in error: $pkh";; *) pass "#21: internal _events name not leaked";; esac
+    story_cross_tier_move
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Story 6c — Cross-tier move: an UPDATE whose SET changes the partition column
+# across the hot/cold cutoff relocates the row between tiers. Permissive mode
+# (coldfront.allow_mixed_writes, default
+# on) performs the move; strict mode rejects it. Each scenario seeds its own
+# rows with a distinct status marker so the counts are independent of prior
+# stories. "Hot" is membership in the _events heap; total is the view.
+#  - HOT ts that has a pre-made partition: now-1mo + 10d (m1, seeded hot above).
+#  - COLD ts: now-4mo + 10d (m4, archived).
+# ───────────────────────────────────────────────────────────────────────────
+story_cross_tier_move() {
+    step "6c. Cross-tier move (partition-key UPDATE relocates the row)"
+    local O; O=$(qf "$HOST" <<'EOSQL'
+-- cold→hot: seed one cold row, then move its ts into the hot range.
+INSERT INTO events (ts, status, data) VALUES (date_trunc('month',now()) - interval '4 months' + interval '10 days','move_c2h','{}');
+UPDATE events SET ts = date_trunc('month',now()) - interval '1 month' + interval '10 days' WHERE status='move_c2h';
+SELECT 'C2H_TOTAL:' || count(*) FROM events  WHERE status='move_c2h';
+SELECT 'C2H_HOT:'   || count(*) FROM _events WHERE status='move_c2h';
+-- hot→cold: seed one hot row, then move its ts into the cold range.
+INSERT INTO events (ts, status, data) VALUES (date_trunc('month',now()) - interval '1 month' + interval '10 days','move_h2c','{}');
+UPDATE events SET ts = date_trunc('month',now()) - interval '4 months' + interval '10 days' WHERE status='move_h2c';
+SELECT 'H2C_TOTAL:' || count(*) FROM events  WHERE status='move_h2c';
+SELECT 'H2C_HOT:'   || count(*) FROM _events WHERE status='move_h2c';
+-- row-dependent SET that moves only SOME rows: one cold row crosses into hot
+-- (cold + 4mo lands in m1 hot), one stays cold (m4 + 1mo = m3, still cold).
+INSERT INTO events (ts, status, data) VALUES (date_trunc('month',now()) - interval '3 months' + interval '10 days','move_mix','{}');
+INSERT INTO events (ts, status, data) VALUES (date_trunc('month',now()) - interval '4 months' + interval '10 days','move_mix','{}');
+SELECT 'MIX_TOTAL_PRE:' || count(*) FROM events WHERE status='move_mix';
+UPDATE events SET ts = ts + interval '2 months' WHERE status='move_mix';
+SELECT 'MIX_TOTAL_POST:' || count(*) FROM events  WHERE status='move_mix';
+SELECT 'MIX_HOT_POST:'   || count(*) FROM _events WHERE status='move_mix';
+-- A row-dependent SET with a value-independent WHERE must apply the new value
+-- exactly once: the cold→hot row, once inserted into the heap, must not be
+-- updated a second time by the in-place stay-hot UPDATE. m3+10d + 2mo = m1+10d.
+INSERT INTO events (ts, status, data) VALUES (date_trunc('month',now()) - interval '3 months' + interval '10 days','move_dbl','{}');
+UPDATE events SET ts = ts + interval '2 months' WHERE status='move_dbl';
+SELECT 'DBL_ONCE:' || (ts = date_trunc('month',now()) - interval '1 month' + interval '10 days')::text FROM events WHERE status='move_dbl';
+EOSQL
+)
+    assert_eq "cold→hot move: row preserved (total)" "1" "$(extract C2H_TOTAL "$O")"
+    assert_eq "cold→hot move: row now in the hot heap" "1" "$(extract C2H_HOT "$O")"
+    assert_eq "hot→cold move: row preserved (total)" "1" "$(extract H2C_TOTAL "$O")"
+    assert_eq "hot→cold move: row no longer in the hot heap" "0" "$(extract H2C_HOT "$O")"
+    # A row-dependent SET moves only the rows whose new ts crosses the cutoff; no
+    # row is lost and the partial split lands in the right tiers.
+    local mp; mp=$(extract MIX_TOTAL_PRE "$O")
+    assert_eq "row-dependent move: no row lost (total preserved)" "$mp" "$(extract MIX_TOTAL_POST "$O")"
+    assert_eq "row-dependent move: exactly the crossing row went hot" "1" "$(extract MIX_HOT_POST "$O")"
+    # The crossing row's new value is applied exactly once, not re-applied by the
+    # in-place stay-hot UPDATE after it is inserted into the heap.
+    assert_eq "row-dependent cold→hot move applies the new value exactly once" "true" "$(extract DBL_ONCE "$O")"
+    # A move whose target hot ts has no pre-made partition is rejected cleanly,
+    # naming the view, and must not leak the internal _events heap name in any form.
+    local np; np=$(q_may "$HOST" "UPDATE events SET ts = now() + interval '20 years' WHERE status='move_c2h';")
+    assert_err "move to a ts with no hot partition rejected" "events" "$np"
+    case "$np" in
+        *"no partition of relation"*) fail "raw partition-routing error leaked: $np";;
+        *_events*)                    fail "internal _events name leaked: $np";;
+        *)                            pass "no raw partition error or _events name leaked";;
+    esac
+    # Strict mode still rejects any partition-key SET (no atomic move to fall back on).
+    local sm; sm=$(q_may "$HOST" "SET coldfront.allow_mixed_writes=off; UPDATE events SET ts = date_trunc('month',now()) - interval '4 months' + interval '10 days' WHERE status='move_c2h';")
+    assert_err "strict mode rejects the cross-tier move" "partition column" "$sm"
 }
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/docs/architecture_tiered.md
+++ b/docs/architecture_tiered.md
@@ -227,12 +227,30 @@ Subqueries, UDF calls, and expressions on the partition column are
 AMBIGUOUS.
 
 The tier classification above applies to the WHERE clause. The SET
-clause carries a separate rule: an `UPDATE` that assigns the partition
-column itself is rejected, regardless of `coldfront.allow_mixed_writes`.
-Changing the partition column can move a row across the cutoff, and the
-in-place rewrite would leave the row in its old tier where the view's
-tier predicate then hides it. To change the partition column, delete the
-row and re-insert it with the new value.
+clause carries a separate rule for the partition column itself, because
+changing it can move a row across the cutoff. An in-place per-tier
+rewrite would leave such a row in its old tier where the view's tier
+predicate then hides it, so the hook handles a partition-column SET
+separately by the `coldfront.allow_mixed_writes` GUC:
+
+- Permissive (on, default): the hook rewrites the UPDATE to
+  `SELECT coldfront._cross_tier_move(...)`, which RELOCATES each matched
+  row between tiers. The function reads the affected rows once, then
+  applies four disjoint cases by current tier and new value: stay-hot
+  (in-place heap UPDATE), stay-cold (re-add to Iceberg with the new
+  value), hot to cold (heap DELETE plus Iceberg INSERT), and cold to hot
+  (heap INSERT plus Iceberg DELETE). The hot side is plain PG; the cold
+  side is one `duckdb.raw_query` (DELETE plus INSERT, one Iceberg
+  snapshot) under one bakery claim. A target value with no covering hot
+  partition is rejected naming the view; the move is not supported inside
+  a function or DO block, with bound parameters, with a VOLATILE new
+  value, with a bare NULL new value, with a new value referencing other
+  columns, or alongside a SET of other columns.
+- Strict (off): the hook rejects the partition-column SET. To change the
+  partition column, delete the row and re-insert it with the new value.
+
+Before anything is archived (no cutoff) every row is hot, so a
+partition-column UPDATE is a plain hot UPDATE in either mode.
 
 ## Write modes: strict vs permissive (`allow_mixed_writes`)
 

--- a/docs/formal/README.md
+++ b/docs/formal/README.md
@@ -361,6 +361,26 @@ already evolved by the originator. The single-commit shape thus holds -
 the catalog is altered exactly once, by one claimant - and peers only
 rebuild their per-node view.
 
+### Cross-tier move (partition-column UPDATE)
+
+A partition-column `UPDATE` that crosses the cutoff is rewritten to
+`coldfront._cross_tier_move`, which relocates rows between tiers.
+Its hot-tier work is plain PostgreSQL (heap INSERT/UPDATE/DELETE - no
+Iceberg, no claim). Its cold-tier work is **one** `duckdb.raw_query`
+issued through the **unchanged** path: a single DELETE-set plus
+INSERT-set in one DuckDB MetaTransaction - one Iceberg snapshot, one
+Lakekeeper CAS POST - under **one** `_claim_iceberg_lock` held to
+transaction end (released by the C `XactCallback`). It is therefore the
+**same stock-ordering single claimant** the cold writer is: one CAS
+commit (identical parent-CAS conflict shape to the append modelled at
+`Decide`) under the held claim. It forces `iceberg_async_parquet = off`
+(`AsyncParquet = FALSE`, `Bakery_v2.cfg`) - the DELETE+INSERT bundle is
+not pg_duckdb's single deferred POST that the async re-stamp patch wraps.
+Exactly **one** claim per move (a second `_claim_iceberg_lock` on the
+same table in one txn would self-deadlock at the min-ticket gate), so the
+move never holds two tickets. No new protocol primitive is added, so the
+model and every config result are unchanged.
+
 ### Partition detach fan-out
 
 The retention path detaches expired partitions with

--- a/extension/coldfront/Makefile
+++ b/extension/coldfront/Makefile
@@ -13,7 +13,7 @@ EXTENSION   = coldfront
 DATA        = coldfront--1.0.sql coldfront--0.1--1.0.sql
 REGRESS     = load_order update_unregistered_view update_heap_table \
               update_hot_via_view update_cold_via_view update_ambiguous_rejected \
-              update_partition_key_blocked \
+              update_partition_key_blocked update_partition_key_move \
               returning_literal_in_where cast_literal_in_value \
               classify_between_in_or classify_now allow_mixed_writes cold_write_batch_size_guc \
               dollar_quote_in_value mixed_case_identifier \

--- a/extension/coldfront/coldfront--1.0.sql
+++ b/extension/coldfront/coldfront--1.0.sql
@@ -319,6 +319,10 @@ BEGIN
     WHERE p.pronamespace = 'coldfront'::regnamespace
       AND p.proname IN ('ensure_attached', 'ensure_pg_attached',
                         '_exec_iceberg_with_claim', '_tiered_insert_cold',
+                        -- cross-tier move: the hook rewrites a partition-column
+                        -- UPDATE to SELECT _cross_tier_move(...), which serialises
+                        -- cold rows via _move_row_literal.
+                        '_cross_tier_move', '_move_row_literal', '_move_pg_row_literal',
                         '_enqueue_release',
                         -- R-A bakery coordination (mesh cold writes); SECURITY
                         -- DEFINER, so the app role just needs EXECUTE — the
@@ -870,6 +874,309 @@ BEGIN
 END;
 $$;
 
+-- coldfront._cross_tier_move: execute a partition-column UPDATE that crosses the
+-- hot/cold cutoff, relocating the matched rows between tiers. The C post-parse-
+-- analyze hook detects the move (partition column in
+-- SET, cutoff present, coldfront.allow_mixed_writes on), deparses the user WHERE
+-- (p_where) and the new partition-column value e (p_newpc) over the VIEW's columns,
+-- and installs `SELECT coldfront._cross_tier_move(schema, view, where, e)` as the
+-- statement — so this runs at top level, in the user's one transaction.
+--
+-- It is the mixed-tier-update shape (hot tier = plain PG, cold tier = one
+-- duckdb.raw_query under one bakery claim), with rows routed by (current tier,
+-- e vs cutoff) into four disjoint cases handled separately:
+--   stay-hot  hot,  e>=cut : in-place UPDATE of the hot heap.
+--   hot→cold  hot,  e<cut  : the row leaves the heap (DELETE) and is added to
+--                            Iceberg (INSERT).
+--   cold→hot  cold, e>=cut : the row is read from Iceberg into the heap (INSERT
+--                            … FROM iceberg_scan) and removed from Iceberg.
+--   stay-cold cold, e<cut  : removed from Iceberg and re-added with the new ts.
+-- Same-tier changes are in-place; crossings write the OTHER tier and remove from
+-- the origin (different relations) — no same-relation overlap.
+--
+-- Cold tier: ONE raw_query (DELETE-set + INSERT-set = one MetaTransaction = one
+-- snapshot, the replay_archive_delta idiom; the single delete-bearing op pg_duckdb
+-- allows per table per tx) under ONE claim (never per-row tickets). cold→hot reads
+-- Iceberg with iceberg_scan, which pg_duckdb permits inside a function only with
+-- duckdb.unsafe_allow_execution_inside_functions — the move needs it because the
+-- legs are deparsed and run together here. The cold rows destined to stay/return
+-- cold are serialised by VALUE from an iceberg_scan cursor (so no uncommitted-
+-- staging visibility problem and no second claim); hot→cold rows are serialised
+-- from a heap cursor. DELETE is by the OLD primary key; old/new keys differ (the
+-- partition column changed) so it never hits a just-inserted row.
+CREATE FUNCTION coldfront._cross_tier_move(
+    p_view_schema text, p_view_name text, p_where text, p_newpc text
+) RETURNS void
+LANGUAGE plpgsql AS $fn$
+DECLARE
+    v_hot_table   text;
+    v_iceberg     text;
+    v_partcol     text;
+    v_cutoff      timestamptz;
+    v_hot_schema  text;
+    v_hot_relname text;
+    v_cut_lit     text;          -- 'YYYY-…'::timestamptz of the cutoff
+    v_pc          text;          -- quoted partition column
+    v_cols        text;          -- heap col list (all live cols), quoted
+    v_cold_read   text;          -- iceberg_scan surface projection: r[col]::cast AS col
+    v_has_ident   boolean;
+    v_inner       text;          -- "SELECT v_cold_read FROM iceberg_scan(ice) r WHERE r[pc] < cut"
+    full_cols     text[];
+    full_types    text[];
+    pk_names      text[];
+    pk_types      text[];          -- Iceberg storage type per PK column (for DELETE casts)
+    v_pk_list     text;
+    cur           refcursor;
+    rec           record;
+    payload       jsonb;
+    pk_lit        text;
+    ins_arr       text[] := '{}'; -- cold-destined Iceberg VALUES tuples (DuckDB literals)
+    heap_arr      text[] := '{}'; -- cold→hot heap VALUES tuples (PG literals)
+    del_arr       text[] := '{}'; -- OLD primary-key tuples to DELETE from Iceberg
+    cold_sql      text := '';
+    v_targets     timestamptz[];
+    v_hot_targets timestamptz[];
+    v_uncovered   bigint;
+    my_ticket     bigint;
+    v_armed       boolean := NULLIF(current_setting('snowflake.node', true), '') IS NOT NULL
+                         AND NULLIF(current_setting('coldfront.dblink_self', true), '') IS NOT NULL;
+BEGIN
+    SET LOCAL duckdb.unsafe_allow_execution_inside_functions = on;
+    SET LOCAL duckdb.unsafe_allow_mixed_transactions = on;
+    SET LOCAL coldfront.iceberg_async_parquet = off;
+    SET LOCAL bytea_output = 'hex';
+
+    SELECT tv.hot_table, tv.iceberg_table, tv.partition_col, aw.cutoff_time
+    INTO v_hot_table, v_iceberg, v_partcol, v_cutoff
+    FROM coldfront.tiered_views tv
+    LEFT JOIN coldfront.archive_watermark aw ON aw.table_name = p_view_name
+    WHERE tv.schema_name = p_view_schema AND tv.relname = p_view_name;
+    IF v_hot_table IS NULL OR v_cutoff IS NULL THEN
+        RAISE EXCEPTION 'coldfront: cross-tier move on %.% requires a tiered view with a cutoff',
+            p_view_schema, p_view_name;
+    END IF;
+
+    v_hot_schema  := (parse_ident(v_hot_table))[1];
+    v_hot_relname := (parse_ident(v_hot_table))[2];
+    v_pc          := quote_ident(v_partcol);
+    v_cut_lit     := quote_literal(to_char(v_cutoff AT TIME ZONE 'UTC',
+                                           'YYYY-MM-DD HH24:MI:SS.US+00')) || '::timestamptz';
+
+    -- All live heap columns in attnum order — names, types, and whether any is an
+    -- identity column — in ONE catalog scan. v_cols (quoted list) and v_cold_read
+    -- (the iceberg_scan surface projection r[col]::cast AS col) derive from the
+    -- arrays, mirroring _rebuild_tiered_view's casts (one source of truth via
+    -- _iceberg_view_cast_type / _iceberg_storage_type; view cast, else storage).
+    SELECT array_agg(a.attname ORDER BY a.attnum),
+           array_agg(format_type(a.atttypid, a.atttypmod) ORDER BY a.attnum),
+           bool_or(a.attidentity <> '')
+    INTO full_cols, full_types, v_has_ident
+    FROM pg_attribute a JOIN pg_class c ON c.oid = a.attrelid
+    JOIN pg_namespace nn ON nn.oid = c.relnamespace
+    WHERE nn.nspname = v_hot_schema AND c.relname = v_hot_relname
+      AND a.attnum > 0 AND NOT a.attisdropped;
+    SELECT string_agg(quote_ident(col), ', ' ORDER BY ord),
+           string_agg(format('r[%L]::%s AS %I', col,
+                             COALESCE(NULLIF(coldfront._iceberg_view_cast_type(typ), ''),
+                                      coldfront._iceberg_storage_type(typ)), col),
+                      ', ' ORDER BY ord)
+    INTO v_cols, v_cold_read
+    FROM unnest(full_cols, full_types) WITH ORDINALITY AS u(col, typ, ord);
+    SELECT array_agg(a.attname ORDER BY x.ord),
+           array_agg(coldfront._iceberg_storage_type(format_type(a.atttypid, a.atttypmod)) ORDER BY x.ord)
+    INTO pk_names, pk_types
+    FROM pg_index idx JOIN pg_class c ON c.oid = idx.indrelid
+    JOIN pg_namespace nn ON nn.oid = c.relnamespace
+    JOIN unnest(idx.indkey) WITH ORDINALITY AS x(attnum, ord) ON true
+    JOIN pg_attribute a ON a.attrelid = idx.indrelid AND a.attnum = x.attnum
+    WHERE nn.nspname = v_hot_schema AND c.relname = v_hot_relname AND idx.indisprimary;
+    IF pk_names IS NULL THEN
+        RAISE EXCEPTION 'coldfront: cross-tier move on view "%" requires a primary key on the hot table', p_view_name;
+    END IF;
+    SELECT string_agg(quote_ident(nm), ', ' ORDER BY ord) INTO v_pk_list
+    FROM unnest(pk_names) WITH ORDINALITY AS u(nm, ord);
+
+    v_inner := format('SELECT %s FROM iceberg_scan(%L) r WHERE r[%L] < %s',
+                      v_cold_read, v_iceberg, v_partcol, v_cut_lit);
+    PERFORM coldfront.ensure_attached();
+
+    -- Reject a cold→hot target with no covering hot partition, naming the VIEW
+    -- (never the internal heap name): the heap is RANGE-partitioned with no default
+    -- partition, so a row LANDING hot (cold→hot, or stay-hot whose new ts crosses a
+    -- hot-partition boundary) would otherwise raise PG's "no partition of relation
+    -- _events". Collect the distinct new-ts values of all hot-landing rows from both
+    -- tiers — cold via iceberg_scan, hot via the heap — kept in SEPARATE queries so
+    -- one never mixes iceberg_scan (DuckDB) with pg_catalog (which pg_duckdb cannot
+    -- read), then check coverage against pg_inherits leaf bounds (split_part on the
+    -- single-key FOR VALUES FROM ('lo') TO ('hi') rendering; no regex).
+    EXECUTE format(
+        'SELECT array_agg(DISTINCT (%2$s)::timestamptz) FROM ( %1$s ) s WHERE (%3$s) AND (%2$s) >= %4$s',
+        v_inner, p_newpc, p_where, v_cut_lit) INTO v_targets;
+    EXECUTE format(
+        'SELECT array_agg(DISTINCT (%6$s)::timestamptz) FROM %1$I.%2$I WHERE (%5$s) AND %3$s >= %4$s AND (%6$s) >= %4$s',
+        v_hot_schema, v_hot_relname, v_pc, v_cut_lit, p_where, p_newpc) INTO v_hot_targets;
+    v_targets := COALESCE(v_targets, '{}'::timestamptz[]) || COALESCE(v_hot_targets, '{}'::timestamptz[]);
+    IF array_length(v_targets, 1) > 0 THEN
+        SELECT count(*) INTO v_uncovered
+        FROM unnest(v_targets) AS tv
+        WHERE NOT EXISTS (
+            SELECT 1 FROM pg_inherits i JOIN pg_class c ON c.oid = i.inhrelid,
+            LATERAL pg_get_expr(c.relpartbound, c.oid) AS b
+            WHERE i.inhparent = format('%I.%I', v_hot_schema, v_hot_relname)::regclass
+              AND b LIKE 'FOR VALUES FROM %'
+              AND tv >= split_part(b, '''', 2)::timestamptz
+              AND tv <  split_part(b, '''', 4)::timestamptz);
+        IF v_uncovered > 0 THEN
+            RAISE EXCEPTION 'coldfront: cross-tier move on view "%" targets a hot partition that does not exist',
+                p_view_name
+                USING HINT = 'The new partition-column value falls outside the pre-made hot partitions; create the covering partition first, or choose a value within an existing one.';
+        END IF;
+    END IF;
+
+    -- One claim for the whole move (released at xact end by the C XactCallback);
+    -- mesh → R-A bakery, vanilla → local advisory xact lock.
+    IF v_armed THEN
+        my_ticket := coldfront._claim_iceberg_lock(v_iceberg);
+        PERFORM coldfront._enqueue_release(my_ticket);
+    ELSE
+        PERFORM pg_advisory_xact_lock(hashtext('coldfront_iceberg:' || v_iceberg));
+    END IF;
+
+    -- ── Capture the moved rows by VALUE (no iceberg_scan in any modifying stmt) ──
+    -- Affected COLD rows are read with a SELECT cursor over iceberg_scan (a pure
+    -- read, which pg_duckdb runs in DuckDB — a modifying INSERT…FROM iceberg_scan
+    -- would instead trip pg_duckdb's "cannot modify a Postgres table" path). Each
+    -- affected cold row is DELETEd from Iceberg by its OLD pk; rows staying cold are
+    -- re-added to Iceberg with the new ts; rows crossing to hot are added to the
+    -- heap. cf_new_ts is computed in the cursor so e is evaluated once per row.
+    OPEN cur FOR EXECUTE format(
+        'SELECT s.*, (%2$s) AS cf_new_ts FROM ( %1$s ) s WHERE (%3$s)',
+        v_inner, p_newpc, p_where);
+    LOOP
+        FETCH cur INTO rec;
+        EXIT WHEN NOT FOUND;
+        payload := to_jsonb(rec);
+        -- OLD primary key, each part cast to its Iceberg storage type so DuckDB's
+        -- row IN matches the typed columns (a bare string literal would not coerce).
+        SELECT string_agg(quote_literal(payload->>nm) || '::' || typ, ', ' ORDER BY ord)
+        INTO pk_lit
+        FROM unnest(pk_names, pk_types) WITH ORDINALITY AS u(nm, typ, ord);
+        del_arr := del_arr || ('(' || pk_lit || ')');
+
+        IF (payload->>'cf_new_ts')::timestamptz < v_cutoff THEN
+            -- stay-cold: re-add to Iceberg (DuckDB literal tuple).
+            ins_arr := ins_arr || ('(' || coldfront._move_row_literal(payload, full_cols, full_types, v_partcol) || ')');
+        ELSE
+            -- cold→hot: add to the heap (PG literal tuple, partition column = e).
+            heap_arr := heap_arr || ('(' || coldfront._move_pg_row_literal(payload, full_cols, v_partcol) || ')');
+        END IF;
+    END LOOP;
+    CLOSE cur;
+
+    -- hot→cold: remove the crossing rows from the heap and capture them for the
+    -- Iceberg insert in ONE atomic DELETE ... RETURNING, so there is no
+    -- read-then-delete window for a concurrent heap writer to race. cf_new_ts is
+    -- computed over the deleted row, exactly as the cold cursor above does.
+    FOR rec IN EXECUTE format(
+        'DELETE FROM %1$I.%2$I h WHERE (%5$s) AND %3$s >= %4$s AND (%6$s) < %4$s RETURNING h.*, (%6$s) AS cf_new_ts',
+        v_hot_schema, v_hot_relname, v_pc, v_cut_lit, p_where, p_newpc)
+    LOOP
+        payload := to_jsonb(rec);
+        ins_arr := ins_arr || ('(' || coldfront._move_row_literal(payload, full_cols, full_types, v_partcol) || ')');
+    END LOOP;
+
+    -- ── Hot heap (plain PG) ───────────────────────────────────────────────────
+    -- stay-hot: in-place ts change. Runs BEFORE the cold→hot INSERT so a
+    -- row-dependent new value (e.g. ts + interval) is never applied a second time
+    -- to a row this same statement just inserted.
+    EXECUTE format(
+        'UPDATE %1$I.%2$I SET %3$s = (%6$s) WHERE (%5$s) AND %3$s >= %4$s AND (%6$s) >= %4$s',
+        v_hot_schema, v_hot_relname, v_pc, v_cut_lit, p_where, p_newpc);
+    -- cold→hot: INSERT the captured rows (carrying the existing identity).
+    IF array_length(heap_arr, 1) > 0 THEN
+        EXECUTE format('INSERT INTO %1$I.%2$I (%3$s) %4$s VALUES %5$s',
+            v_hot_schema, v_hot_relname, v_cols,
+            CASE WHEN v_has_ident THEN 'OVERRIDING SYSTEM VALUE' ELSE '' END,
+            array_to_string(heap_arr, ', '));
+    END IF;
+
+    -- ── Cold tier: ONE raw_query (DELETE old keys + INSERT cold-destined) ────────
+    IF array_length(del_arr, 1) > 0 THEN
+        cold_sql := format('DELETE FROM %s WHERE (%s) IN (%s)', v_iceberg, v_pk_list, array_to_string(del_arr, ', '));
+    END IF;
+    IF array_length(ins_arr, 1) > 0 THEN
+        IF cold_sql <> '' THEN cold_sql := cold_sql || '; '; END IF;
+        cold_sql := cold_sql || format('INSERT INTO %s VALUES %s', v_iceberg, array_to_string(ins_arr, ', '));
+    END IF;
+    IF cold_sql <> '' THEN
+        PERFORM duckdb.raw_query(cold_sql);
+    END IF;
+END;
+$fn$;
+
+-- coldfront._move_row_literal: render one captured row (jsonb of surface values +
+-- cf_new_ts) as a DuckDB positional VALUES tuple for the Iceberg INSERT, in attnum
+-- order: the partition column takes cf_new_ts; bytea is rebuilt with from_hex on the
+-- hex text (bytea_output is pinned to hex by the caller); a NULL is NULL; everything
+-- else is a quoted literal DuckDB coerces to the storage type. Mirrors
+-- _tiered_insert_cold's per-row serialiser.
+CREATE FUNCTION coldfront._move_row_literal(
+    p_payload jsonb, p_cols text[], p_types text[], p_partcol text
+) RETURNS text
+LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+    row_lit  text := '';
+    col      text;
+    val_text text;
+    i        int;
+BEGIN
+    FOR i IN 1 .. array_length(p_cols, 1) LOOP
+        col := p_cols[i];
+        IF i > 1 THEN row_lit := row_lit || ', '; END IF;
+        IF col = p_partcol THEN
+            row_lit := row_lit || quote_literal(p_payload->>'cf_new_ts');
+        ELSIF p_payload ? col AND jsonb_typeof(p_payload->col) <> 'null' THEN
+            val_text := p_payload->>col;
+            IF p_types[i] = 'bytea' THEN
+                row_lit := row_lit || format('from_hex(%L)', substr(val_text, 3));
+            ELSE
+                row_lit := row_lit || quote_literal(val_text);
+            END IF;
+        ELSE
+            row_lit := row_lit || 'NULL';
+        END IF;
+    END LOOP;
+    RETURN row_lit;
+END;
+$$;
+
+-- coldfront._move_pg_row_literal: the cold→hot counterpart of _move_row_literal —
+-- render a captured row as a positional VALUES tuple for the PG heap INSERT. The
+-- partition column takes cf_new_ts; every other value is an unknown-typed literal
+-- (quote_nullable) that PG coerces to the heap column type on INSERT (so bytea hex
+-- and jsonb text round-trip with no per-type handling). NULL stays NULL.
+CREATE FUNCTION coldfront._move_pg_row_literal(
+    p_payload jsonb, p_cols text[], p_partcol text
+) RETURNS text
+LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+    row_lit text := '';
+    col     text;
+    i       int;
+BEGIN
+    FOR i IN 1 .. array_length(p_cols, 1) LOOP
+        col := p_cols[i];
+        IF i > 1 THEN row_lit := row_lit || ', '; END IF;
+        IF col = p_partcol THEN
+            row_lit := row_lit || quote_nullable(p_payload->>'cf_new_ts');
+        ELSE
+            row_lit := row_lit || quote_nullable(p_payload->>col);
+        END IF;
+    END LOOP;
+    RETURN row_lit;
+END;
+$$;
+
 
 -- replay_archive_delta: drains delta rows whose xid is NOT visible in the
 -- bulk-copy snapshot, applying DELETE-then-INSERT to Iceberg per source PK.
@@ -1354,27 +1661,18 @@ BEGIN
         format('SELECT * FROM ice.default.%s', p_table)
     );
 
-    -- 3. INSTEAD OF INSERT trigger — DROPPED in this version. The C
-    --    post_parse_analyze hook now intercepts INSERT INTO <iceberg-only-view>
-    --    statements (see coldfront.c emit_cold / prefix_pg_tables_with_pglocal)
-    --    and rewrites them into a single bulk
-    --    SELECT duckdb.raw_query('INSERT INTO ice.… VALUES/SELECT …'),
-    --    one Iceberg snapshot for the whole statement, regardless of how many
-    --    rows. INSERT … SELECT FROM <pg_source> gets each PG-table
-    --    reference prefixed with `pglocal.` so DuckDB's postgres extension
-    --    streams source rows over libpq with no local materialisation.
-    --
-    --    Earlier revisions generated a FOR EACH ROW trigger here that did one
-    --    raw_query per row. Bench measured ~50 rows/s under that path and the
-    --    parallel-INSERT case hit 409 CatalogCommitConflicts at every row;
-    --    the hook-rewrite path collapses N row-commits into one.
-    --
-    --    For backwards-compatibility / belt-and-suspenders against future
-    --    coldfront extension being unloaded mid-session, the placeholders /
-    --    new_refs / insert_fmt / trig_fn locals are no longer used and have
-    --    been removed.
+    -- 3. No INSTEAD OF INSERT trigger: the C post_parse_analyze hook intercepts
+    --    INSERT INTO <iceberg-only-view> (see coldfront.c emit_cold /
+    --    prefix_pg_tables_with_pglocal) and rewrites it into a single bulk
+    --    SELECT duckdb.raw_query('INSERT INTO ice.… VALUES/SELECT …') — one
+    --    Iceberg snapshot for the whole statement regardless of row count, so a
+    --    multi-row or parallel INSERT cannot incur per-row 409
+    --    CatalogCommitConflicts. INSERT … SELECT FROM <pg_source> gets each
+    --    PG-table reference prefixed with `pglocal.` so DuckDB's postgres
+    --    extension streams source rows over libpq with no local materialisation.
 
-    -- Drop any leftover trigger from older revisions.
+    -- Drop a per-row insert trigger if one is present (e.g. left by an upgrade);
+    -- this view uses the hook-rewrite path above, not a trigger.
     EXECUTE format(
         'DROP TRIGGER IF EXISTS coldfront_iceonly_insert ON %I.%I',
         p_schema, p_table);
@@ -2394,7 +2692,9 @@ $body$ LANGUAGE plpgsql$fn$,
         v_trigname, v_schema, v_view_name, v_funcname);
 
     -- 6. The registry key (schema, relname) is unchanged by the DROP+CREATE
-    --    above (the view name is stable), so there is nothing to re-point.
+    --    above (the view name is stable), so there is nothing to re-point. The
+    --    cross-tier-move path is the post_parse_analyze hook + coldfront._cross_tier_move;
+    --    it needs no per-view object here.
 END;
 $$;
 

--- a/extension/coldfront/src/coldfront.c
+++ b/extension/coldfront/src/coldfront.c
@@ -45,6 +45,7 @@
 #include "nodes/parsenodes.h"
 #include "nodes/nodeFuncs.h"
 #include "nodes/pg_list.h"
+#include "optimizer/optimizer.h"
 #include "parser/analyze.h"
 #include "tcop/tcopprot.h"
 #include "tcop/utility.h"
@@ -67,9 +68,8 @@ static bool coldfront_in_rewrite = false;
  * Cold-tier DML from inside plpgsql — the two problems and how this file
  * solves them. (Background for the param + dummy-table machinery below.)
  *
- * Cold DML works fine as a top-level statement but used to fail when issued
- * from inside a plpgsql function / DO block / trigger, for TWO independent
- * reasons:
+ * Cold DML works as a top-level statement, but from inside a plpgsql function /
+ * DO block / trigger it faces TWO independent problems:
  *
  *   (1) Bound parameters. plpgsql (and any client using bind params / PREPARE
  *       / the extended protocol) compiles variable references into $N
@@ -77,12 +77,12 @@ static bool coldfront_in_rewrite = false;
  *       which is exactly when this hook runs (there is no executor hook). The
  *       deparser emits those $N as literal text, so the cold SQL handed to
  *       duckdb.raw_query carried "$N" with nothing to bind -> DuckDB error
- *       "Expected N parameters, but none were supplied". FIX: keep the params
- *       LIVE — emit the cold SQL as a runtime format(<template>, $1, $2, ...)
- *       call (cold_sql_arg) and declare the param types on the re-parse, so PG
- *       binds the values at execution and DuckDB only ever sees finished
- *       literals. This applies EVERYWHERE (top level and plpgsql) and needs no
- *       table.
+ *       "Expected N parameters, but none were supplied". The hook keeps the
+ *       params LIVE — it emits the cold SQL as a runtime
+ *       format(<template>, $1, $2, ...) call (cold_sql_arg) and declares the
+ *       param types on the re-parse, so PG binds the values at execution and
+ *       DuckDB only ever sees finished literals. This applies EVERYWHERE (top
+ *       level and plpgsql) and needs no table.
  *
  *   (2) Statement shape. The cold rewrite is a row-returning
  *       `SELECT coldfront._exec_iceberg_with_claim(...)`. At top level the
@@ -93,11 +93,11 @@ static bool coldfront_in_rewrite = false;
  *       (those are plpgsql source constructs, fixed before this hook runs and
  *       unreachable from it), and the cold "table" is a DuckDB-attached object,
  *       not a PG relation, so PG can't tag a real UPDATE/DELETE against it.
- *       FIX (only where needed): when — and only when — this statement is being
- *       parsed inside plpgsql, wrap the cold call as a DML over the dummy
- *       carrier coldfront._dummy_dml_target (see cold_anchor_update + that
- *       table's comment in coldfront--1.0.sql). At top level we keep today's
- *       SELECT shape byte-for-byte, so nothing there changes.
+ *       Handled only where needed: when — and only when — this statement is
+ *       parsed inside plpgsql, the hook wraps the cold call as a DML over the
+ *       dummy carrier coldfront._dummy_dml_target (see cold_anchor_update + that
+ *       table's comment in coldfront--1.0.sql). At top level the SELECT shape is
+ *       kept byte-for-byte.
  *
  * Detecting "are we inside plpgsql?" without interfering with anything: when
  * plpgsql parses one of its statements it installs p_post_columnref_hook on the
@@ -115,7 +115,7 @@ static bool coldfront_in_rewrite = false;
  * block / PREPARE / the extended protocol. Their VALUES are unknown at
  * parse-analyze (they bind only at execution), so the cold SQL keeps the $N
  * live and renders them via format() at run time (see cold_sql_arg). maxid==0
- * means there are none (the path is then byte-identical to the old literal).
+ * means there are none (the path is then byte-identical to the plain literal path).
  */
 #define COLDFRONT_MAX_PARAMS 1024       /* plpgsql dno+1; far above any real arity */
 typedef struct ColdParamSet
@@ -190,9 +190,9 @@ static int  coldfront_cold_write_batch_size = 10000;
  * DEFINER (they must run elevated so the side-loaded iceberg/postgres
  * extensions load past pg_duckdb's non-superuser LocalFileSystem block), so a
  * non-superuser must NOT be able to redirect the elevated ATTACH at an
- * attacker endpoint. Defining these formally as PGC_SUSET (vs. the bare
- * placeholders they used to be) makes them settable only by superusers / roles
- * granted SET on them — operators still set them in postgresql.conf, where they
+ * attacker endpoint. Defining these formally as PGC_SUSET makes them settable
+ * only by superusers / roles granted SET on them — operators still set them in
+ * postgresql.conf, where they
  * ride physical replication unchanged. local_pg_dsn is GUC_SUPERUSER_ONLY too:
  * it can carry libpq credentials, so non-superusers must not read it back.
  * The values are read SQL-side via current_setting(); these backing vars exist
@@ -1142,12 +1142,13 @@ query_has_pg_source_table(Query *query)
  * with no local materialisation.
  *
  * We walk the Query's rtable, build the qualified `<schema>.<table>`
- * string for each non-result RTE_RELATION, and substitute every literal
+ * string for each non-result RTE_RELATION, and substitute every
  * occurrence in sql with `pglocal.<schema>.<table>`. The substitution is
- * textual; quote_identifier matches what pg_get_querydef emits, so the
- * search patterns line up exactly. False positives are theoretically
- * possible if a column or alias happens to match the qualified-name
- * literal — vanishingly rare in practice and we accept the risk.
+ * quote-aware: an occurrence inside a single-quoted string literal is user
+ * data, not a table reference, and is left untouched; a word-boundary check
+ * keeps a column or alias that merely shares the table's identifier from
+ * being rewritten. quote_identifier matches what pg_get_querydef emits, so
+ * the search patterns line up exactly.
  */
 /* Walk an rtable and collect every PG-table relid, recursing into
  * RTE_SUBQUERY (INSERT … SELECT wraps the SELECT side in a subquery). */
@@ -2238,49 +2239,212 @@ cf_reject_multi_reference(Query *query, RangeTblEntry *rte)
 }
 
 /*
- * Reject an UPDATE that assigns the partition column of a tiered view. Changing
- * the partition column can move the row across the hot/cold cutoff; the in-place
- * rewrite (hot, cold, or dual) updates the row where it already lives, so a moved
- * row stays physically in its old tier while the view's tier predicate
- * (ts >= cutoff / r[ts] < cutoff) filters it out — a silent disappearance
- * (GitHub #20). Relocating the row across tiers is a separate, unimplemented
- * feature; until then the partition column is read-only through the view. The
- * targetList here is post-parse-analyze, so it holds exactly the SET-assigned
- * columns (plus resjunk entries we skip) — not the full row. Blocks any assignment
- * regardless of the new value's tier or coldfront.allow_mixed_writes: with no move
- * to permit, allowing it would just reinstate the loss.
+ * The SET assignment for the partition column, if this UPDATE assigns it; else
+ * NULL. Changing the partition column can move the row across the hot/cold
+ * cutoff, so it gets special handling: a cross-tier MOVE when mixed writes are
+ * on, a clean rejection when off (the in-place rewrite would otherwise strand
+ * the row in its old tier where the view's tier predicate hides it). The
+ * targetList here is post-parse-analyze, so it holds exactly the
+ * SET-assigned columns (plus resjunk entries we skip) — not the full row.
  */
-static void
-cf_reject_partition_col_update(Query *query, RangeTblEntry *rte,
-                               TieredViewInfo *info)
+static TargetEntry *
+partcol_set_target(Query *query, RangeTblEntry *rte, TieredViewInfo *info)
 {
     AttrNumber  partcol_attno;
     ListCell   *lc;
 
     if (query->commandType != CMD_UPDATE || info->partition_col == NULL)
-        return;
+        return NULL;
 
     partcol_attno = get_attnum(rte->relid, info->partition_col);
     if (partcol_attno == InvalidAttrNumber)
-        return;
+        return NULL;
 
     foreach(lc, query->targetList)
     {
         TargetEntry *tle = (TargetEntry *) lfirst(lc);
+        if (!tle->resjunk && tle->resno == partcol_attno)
+            return tle;
+    }
+    return NULL;
+}
 
-        if (tle->resjunk)
-            continue;
-        if (tle->resno == partcol_attno)
+/*
+ * Strict-mode (coldfront.allow_mixed_writes = off) rejection of a partition-
+ * column SET: with mixed writes off there is no atomic cross-tier relocation to
+ * fall back on, so reject rather than strand the row. Message/hint are stable
+ * (golden: update_partition_key_blocked).
+ */
+static void
+reject_partition_col_update(TieredViewInfo *info, const char *vname)
+{
+    ereport(ERROR,
+            (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+             errmsg("UPDATE of partition column \"%s\" on tiered view \"%s\" is not supported",
+                    info->partition_col, vname),
+             errhint("Changing \"%s\" can move the row across the hot/cold "
+                     "boundary; that relocation is not yet supported. To "
+                     "change \"%s\", delete the row and re-insert it with "
+                     "the new value.",
+                     info->partition_col, info->partition_col)));
+}
+
+/*
+ * Walker context: true if any Var references a column OTHER than the partition
+ * column (or a different range-table entry). The cross-tier move re-evaluates
+ * the new partition-column expression e in three places (the PG hot legs and the
+ * DuckDB cold legs) over different column spellings, so v1 supports only an e
+ * that references the partition column or constants — anything else is rejected
+ * cleanly upstream rather than mis-evaluated.
+ */
+typedef struct { Index result_rel; AttrNumber partcol_attno; bool other; } VarRefCtx;
+
+static bool
+expr_refs_other_col_walker(Node *node, void *ctx)
+{
+    VarRefCtx *c = (VarRefCtx *) ctx;
+    if (node == NULL)
+        return false;
+    if (IsA(node, Var))
+    {
+        Var *v = (Var *) node;
+        if ((Index) v->varno != c->result_rel || v->varattno != c->partcol_attno)
+            c->other = true;
+        return false;
+    }
+    return expression_tree_walker(node, expr_refs_other_col_walker, ctx);
+}
+
+
+/*
+ * Reject the cross-tier-move shapes v1 does not support, each with a stable
+ * message: cold RETURNING; a WHERE referencing other tables or sub-queries (the
+ * cold tier is read through DuckDB, which can't correlate with Postgres tables);
+ * bound params (e and WHERE are deparsed to literal text at parse-analyze, where
+ * a param's value is not yet known); a multi-column SET; a VOLATILE e; an e that
+ * references other columns; a bare-NULL e. (in_plpgsql is rejected by the caller
+ * — the move's iceberg_scan read can't run nested inside a function/DO.)
+ */
+static void
+cf_reject_unsupported_move(Query *query, RangeTblEntry *rte,
+                           TieredViewInfo *info, ColdParamSet *ps,
+                           TargetEntry *pc_tle, const char *vname)
+{
+    Node     *e = (Node *) pc_tle->expr;
+    ListCell *lc;
+
+    reject_cold_returning(query, vname);
+
+    /* The move replays the deparsed WHERE against one relation at a time (the hot
+     * heap, and iceberg_scan for the cold tier), so it cannot reference other
+     * tables: the cold tier is read through DuckDB, which can't correlate with
+     * Postgres tables. Reject UPDATE ... FROM and sub-query predicates with a clear
+     * message rather than the opaque "missing FROM-clause entry" they fail with. */
+    if (query->hasSubLinks || list_length(query->rtable) > 1)
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("a cross-tier move on tiered view \"%s\" cannot reference other tables or sub-queries", vname),
+                 errhint("The cold tier is read through DuckDB, which can't join other Postgres tables; the WHERE may use only \"%s\"'s own columns (no UPDATE ... FROM, no sub-select).", vname)));
+
+    if (ps->maxid > 0)
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("a cross-tier move on tiered view \"%s\" cannot use bound parameters", vname),
+                 errhint("Run the UPDATE with literal values for the partition column and WHERE clause.")));
+
+    /* Only the partition column may be SET in a move (v1). A second SET target
+     * would have to be re-projected across all four legs; defer that. */
+    foreach(lc, query->targetList)
+    {
+        TargetEntry *tle = (TargetEntry *) lfirst(lc);
+        if (!tle->resjunk && tle != pc_tle)
             ereport(ERROR,
                     (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-                     errmsg("UPDATE of partition column \"%s\" on tiered view \"%s\" is not supported",
-                            info->partition_col, get_rel_name(rte->relid)),
-                     errhint("Changing \"%s\" can move the row across the hot/cold "
-                             "boundary; that relocation is not yet supported. To "
-                             "change \"%s\", delete the row and re-insert it with "
-                             "the new value.",
+                     errmsg("a cross-tier move on tiered view \"%s\" cannot also set other columns", vname),
+                     errhint("Move the row by setting only \"%s\"; update other columns in a separate statement.",
+                             info->partition_col)));
+    }
+
+    /* Reject VOLATILE — never STABLE. clock_timestamp()/random()/nextval() evaluate
+     * differently per call, so they could classify a row into different tiers
+     * across the move's legs. STABLE expressions (e.g. timestamptz + interval,
+     * which depends on the session timezone) evaluate consistently within this
+     * one transaction, so the legs agree; they are the intended row-dependent
+     * move (SET ts = ts + interval '1 month'). */
+    if (contain_volatile_functions(e))
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("the new value for partition column \"%s\" on tiered view \"%s\" must not be VOLATILE",
+                        info->partition_col, vname),
+                 errhint("clock_timestamp()/random()/nextval() can classify a row into different tiers across the move's legs; use a constant or a stable expression over \"%s\" only.",
+                         info->partition_col)));
+
+    {
+        VarRefCtx vc = { (Index) query->resultRelation,
+                         get_attnum(rte->relid, info->partition_col), false };
+        if (expr_refs_other_col_walker(e, &vc) || vc.other)
+            ereport(ERROR,
+                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                     errmsg("the new value for partition column \"%s\" on tiered view \"%s\" may reference only \"%s\"",
+                            info->partition_col, vname, info->partition_col),
+                     errhint("A cross-tier move supports a constant or an expression over \"%s\" (e.g. \"%s + interval '1 month'\").",
                              info->partition_col, info->partition_col)));
     }
+
+    /* A NULL new value matches no tier and the NOT-NULL partition column would
+     * error mid-move; reject when the expression is provably NULL (a bare NULL
+     * constant). Non-constant NULLs are caught at execution by the column's
+     * NOT NULL constraint on the hot legs. */
+    if (IsA(e, Const) && ((Const *) e)->constisnull)
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("the new value for partition column \"%s\" on tiered view \"%s\" cannot be NULL",
+                        info->partition_col, vname)));
+}
+
+/*
+ * Permissive-mode (coldfront.allow_mixed_writes = on) cross-tier move path.
+ * Validates the move (cf_reject_unsupported_move), then deparses the user WHERE
+ * and the new partition-column expression e over the VIEW's column names and
+ * returns the rewrite "SELECT coldfront._cross_tier_move(schema, view, where, e)".
+ * That function does the relocation: it arms its own GUCs, attaches 'ice', and
+ * routes matched rows into the four tier cases. The work lives there (not in a
+ * hook-installed Query) because cold→hot rows are read with iceberg_scan, which
+ * pg_duckdb runs in DuckDB only as a standalone read — not as the modifying Query
+ * the hook installs — and only inside a function with the unsafe-execution GUC.
+ */
+static char *
+cf_emit_cross_tier_move_path(Query *query, RangeTblEntry *rte,
+                             TieredViewInfo *info, ColdParamSet *ps,
+                             TargetEntry *pc_tle, const char *vname)
+{
+    List          *dpcontext;
+    char          *e_text, *where_text;
+    const char    *ns;
+    StringInfoData buf;
+
+    cf_reject_unsupported_move(query, rte, info, ps, pc_tle, vname);
+
+    /* cf_reject_multi_reference guarantees a single base reference, so the result
+     * relation is the sole rangetable entry (varno 1) and the deparse context maps
+     * the view's columns by it. Defensive: fall back to the strict rejection on an
+     * unexpected shape rather than emit a wrong rewrite. */
+    if (query->resultRelation != 1)
+        reject_partition_col_update(info, vname);
+
+    dpcontext  = deparse_context_for(get_rel_name(rte->relid), rte->relid);
+    e_text     = deparse_expression((Node *) pc_tle->expr, dpcontext, false, false);
+    where_text = (query->jointree && query->jointree->quals)
+                 ? deparse_expression((Node *) query->jointree->quals, dpcontext, false, false)
+                 : pstrdup("true");
+    ns = get_namespace_name(get_rel_namespace(rte->relid));
+
+    initStringInfo(&buf);
+    appendStringInfo(&buf,
+        "SELECT coldfront._cross_tier_move(%s, %s, %s, %s)",
+        quote_literal_cstr(ns), quote_literal_cstr(vname),
+        quote_literal_cstr(where_text), quote_literal_cstr(e_text));
+    return buf.data;
 }
 
 /*
@@ -2292,10 +2456,34 @@ static char *
 cf_dispatch_emit(Query *query, RangeTblEntry *rte, TieredViewInfo *info,
                  ColdParamSet *ps, bool in_plpgsql, const char *vname)
 {
-    TierClass tier;
+    TierClass    tier;
+    TargetEntry *pc_tle;
 
     cf_reject_multi_reference(query, rte);
-    cf_reject_partition_col_update(query, rte, info);
+
+    /* A partition-column SET can move the row across the hot/cold cutoff — but
+     * only once something is archived. With a cutoff: mixed writes off → reject;
+     * on → cross-tier move: rewrite to
+     * SELECT coldfront._cross_tier_move(...). Without a cutoff every row is hot, so
+     * a partition-column UPDATE is a plain hot UPDATE — fall through to the normal
+     * classification (emit_hot). Also falls through when the partition column is not
+     * in the SET targetlist. */
+    pc_tle = partcol_set_target(query, rte, info);
+    if (pc_tle != NULL && info->has_cutoff)
+    {
+        if (!coldfront_allow_mixed_writes)
+            reject_partition_col_update(info, vname);
+        /* The rewrite is a row-returning SELECT (the function returns void); inside
+         * a plpgsql function/DO a bare SELECT has no destination. Reject there for
+         * v1 (the top-level form is the supported path). */
+        if (in_plpgsql)
+            ereport(ERROR,
+                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                     errmsg("a cross-tier move of partition column \"%s\" on tiered view \"%s\" is not supported inside a function or DO block",
+                            info->partition_col, vname),
+                     errhint("Run the partition-column UPDATE as a top-level statement.")));
+        return cf_emit_cross_tier_move_path(query, rte, info, ps, pc_tle, vname);
+    }
 
     /* Tiered-view INSERT: bulk split-by-watermark via emit_tiered_insert.
      * Iceberg-only INSERT falls through to the unconditional cold path

--- a/extension/coldfront/test/expected/update_partition_key_blocked.out
+++ b/extension/coldfront/test/expected/update_partition_key_blocked.out
@@ -1,9 +1,10 @@
--- An UPDATE that assigns the partition column of a tiered view is blocked: such
--- a SET can move the row across the hot/cold cutoff, which the in-place rewrite
--- would lose silently (GitHub #20). The hook must ereport(ERROR) with SQLSTATE
--- 0A000 (ERRCODE_FEATURE_NOT_SUPPORTED) regardless of coldfront.allow_mixed_writes
--- and regardless of which tier the WHERE selects. Relocating the row is a separate
--- feature; until then the partition column is read-only via the view.
+-- STRICT mode (coldfront.allow_mixed_writes = off): an UPDATE that assigns the
+-- partition column of a tiered view is rejected. Such a SET can move the row
+-- across the hot/cold cutoff; with mixed writes off there is no atomic relocation
+-- to fall back on, so the hook must ereport(ERROR) with SQLSTATE 0A000
+-- (ERRCODE_FEATURE_NOT_SUPPORTED) regardless of which tier the WHERE selects.
+-- The permissive-mode counterpart (the actual cross-tier move) is covered by
+-- update_partition_key_move.sql; the live round-trip is ci/journey.sh.
 CREATE EXTENSION IF NOT EXISTS pg_duckdb;
 NOTICE:  extension "pg_duckdb" already exists, skipping
 CREATE EXTENSION IF NOT EXISTS coldfront;
@@ -19,36 +20,31 @@ INSERT INTO coldfront.tiered_views(schema_name, relname, hot_table, iceberg_tabl
 VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
 INSERT INTO coldfront.archive_watermark(table_name, cutoff_time)
 VALUES ('events', '2026-03-01'::timestamptz);
--- Permissive mode (default): a partition-column SET is still blocked, because
--- the move is not implemented and the dual-tier rewrite would lose the row.
-SET coldfront.allow_mixed_writes = on;
--- Cold→hot crossing (the #20 repro): blocked.
+-- Strict mode: no cross-tier move, so every partition-column SET is rejected.
+SET coldfront.allow_mixed_writes = off;
+-- Cold→hot crossing: rejected.
 UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE status = 'hot_orig';
 ERROR:  UPDATE of partition column "ts" on tiered view "events" is not supported
 HINT:  Changing "ts" can move the row across the hot/cold boundary; that relocation is not yet supported. To change "ts", delete the row and re-insert it with the new value.
--- Hot→cold crossing: blocked too (symmetric loss).
+-- Hot→cold crossing: rejected too (symmetric loss).
 UPDATE public.events SET ts = '2026-01-05 10:00:00+00' WHERE ts = '2026-04-01 12:00:00+00';
 ERROR:  UPDATE of partition column "ts" on tiered view "events" is not supported
 HINT:  Changing "ts" can move the row across the hot/cold boundary; that relocation is not yet supported. To change "ts", delete the row and re-insert it with the new value.
--- Same-tier constant SET is also blocked (blunt block; no per-value proof).
+-- Same-tier constant SET is also rejected (blunt block; no per-value proof).
 UPDATE public.events SET ts = '2026-04-02 12:00:00+00' WHERE ts = '2026-04-01 12:00:00+00';
 ERROR:  UPDATE of partition column "ts" on tiered view "events" is not supported
 HINT:  Changing "ts" can move the row across the hot/cold boundary; that relocation is not yet supported. To change "ts", delete the row and re-insert it with the new value.
--- Non-constant partition-column SET (could cross per-row): blocked.
+-- Non-constant partition-column SET (could cross per-row): rejected.
 UPDATE public.events SET ts = ts + interval '6 months' WHERE id = 1;
 ERROR:  UPDATE of partition column "ts" on tiered view "events" is not supported
 HINT:  Changing "ts" can move the row across the hot/cold boundary; that relocation is not yet supported. To change "ts", delete the row and re-insert it with the new value.
--- A tier-deterministic WHERE does not rescue a partition-column SET: blocked.
+-- A tier-deterministic WHERE does not rescue a partition-column SET: rejected.
 UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE ts = '2026-01-15 01:00:00+00';
 ERROR:  UPDATE of partition column "ts" on tiered view "events" is not supported
 HINT:  Changing "ts" can move the row across the hot/cold boundary; that relocation is not yet supported. To change "ts", delete the row and re-insert it with the new value.
--- Strict mode: same block.
-SET coldfront.allow_mixed_writes = off;
-UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE status = 'hot_orig';
-ERROR:  UPDATE of partition column "ts" on tiered view "events" is not supported
-HINT:  Changing "ts" can move the row across the hot/cold boundary; that relocation is not yet supported. To change "ts", delete the row and re-insert it with the new value.
 -- A SET that does NOT touch the partition column is unaffected (still routes by
--- WHERE tier — here hot, plain PG).
+-- WHERE tier — here hot, plain PG). This guards that the strict gate did not
+-- over-broaden into ordinary updates.
 UPDATE public.events SET status = 'ok' WHERE ts = '2026-04-01 12:00:00+00';
 -- _events: only the status update applied; every ts-changing statement errored.
 SELECT id, ts, status FROM public._events ORDER BY id;

--- a/extension/coldfront/test/expected/update_partition_key_move.out
+++ b/extension/coldfront/test/expected/update_partition_key_move.out
@@ -1,0 +1,83 @@
+-- PERMISSIVE mode (coldfront.allow_mixed_writes = on, the default): an UPDATE that
+-- assigns the partition column of a tiered view is rewritten into a single
+-- coldfront._cross_tier_move(...) call that relocates the matched rows across the
+-- hot/cold cutoff. White-box: we assert the rewrite shape via
+-- EXPLAIN VERBOSE — the rewritten statement is just the function call (no
+-- iceberg_scan in it, so the planner needs no Iceberg catalog). The live tier
+-- relocation is exercised in ci/journey.sh. v1 rejects, at parse-analyze, the move
+-- shapes the function does not support.
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+NOTICE:  extension "pg_duckdb" already exists, skipping
+CREATE EXTENSION IF NOT EXISTS coldfront;
+NOTICE:  extension "coldfront" already exists, skipping
+SET TIME ZONE 'UTC';
+-- White-box: checks the hooks' SQL/DDL, not Iceberg I/O. Real cold I/O is ci/journey.sh; see README.md.
+SET coldfront.warehouse = '';
+SET coldfront.lakekeeper_endpoint = '';
+CREATE TABLE public._events (id int, ts timestamptz, status text);
+CREATE VIEW public.events AS SELECT * FROM public._events;
+INSERT INTO coldfront.tiered_views(schema_name, relname, hot_table, iceberg_table, partition_col)
+VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
+INSERT INTO coldfront.archive_watermark(table_name, cutoff_time)
+VALUES ('events', '2026-03-01'::timestamptz);
+SET coldfront.allow_mixed_writes = on;
+-- (1) Constant new ts, WHERE on a non-partition column: the rewrite is one
+-- _cross_tier_move call carrying the deparsed WHERE and new-ts expression.
+EXPLAIN (COSTS OFF, VERBOSE)
+  UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE status = 'x';
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   Output: _cross_tier_move('public'::text, 'events'::text, '(status = ''x''::text)'::text, '''Thu Jun 18 10:00:00 2026 UTC''::timestamp with time zone'::text)
+(2 rows)
+
+-- (2) Row-dependent new ts (ts + interval), tier-deterministic WHERE: same shape;
+-- the new-ts expression is the interval arithmetic over the partition column.
+EXPLAIN (COSTS OFF, VERBOSE)
+  UPDATE public.events SET ts = ts + interval '6 months' WHERE ts < '2026-02-01+00';
+                                                                                  QUERY PLAN                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   Output: _cross_tier_move('public'::text, 'events'::text, '(ts < ''Sun Feb 01 00:00:00 2026 UTC''::timestamp with time zone)'::text, '(ts + ''@ 6 mons''::interval)'::text)
+(2 rows)
+
+-- (3) Rejections at parse-analyze (no tier write):
+-- a VOLATILE new value (re-evaluates per row → could split a row across tiers).
+UPDATE public.events SET ts = clock_timestamp() WHERE status = 'x';
+ERROR:  the new value for partition column "ts" on tiered view "events" must not be VOLATILE
+HINT:  clock_timestamp()/random()/nextval() can classify a row into different tiers across the move's legs; use a constant or a stable expression over "ts" only.
+-- new value references a column other than the partition column.
+UPDATE public.events SET ts = make_timestamptz(2026, 6, 1, 0, 0, 0) + (id || ' days')::interval WHERE status = 'x';
+ERROR:  the new value for partition column "ts" on tiered view "events" may reference only "ts"
+HINT:  A cross-tier move supports a constant or an expression over "ts" (e.g. "ts + interval '1 month'").
+-- a multi-column SET that also moves the partition column.
+UPDATE public.events SET ts = '2026-06-18 10:00:00+00', status = 'y' WHERE status = 'x';
+ERROR:  a cross-tier move on tiered view "events" cannot also set other columns
+HINT:  Move the row by setting only "ts"; update other columns in a separate statement.
+-- RETURNING from a move (the cold tier cannot return rows).
+UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE status = 'x' RETURNING id;
+ERROR:  RETURNING is not supported for writes to the cold tier of "events"
+HINT:  The cold tier (Iceberg) cannot return affected rows — duckdb-iceberg does not support RETURNING on writes. Re-run without RETURNING.
+-- a WHERE that pulls in other tables / sub-queries: the cold tier is read in
+-- DuckDB, which can't correlate with Postgres tables, so it is rejected up front.
+UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE id IN (SELECT 1);
+ERROR:  a cross-tier move on tiered view "events" cannot reference other tables or sub-queries
+HINT:  The cold tier is read through DuckDB, which can't join other Postgres tables; the WHERE may use only "events"'s own columns (no UPDATE ... FROM, no sub-select).
+-- Without a cutoff (nothing archived) a partition-column UPDATE is a plain hot
+-- UPDATE — no move, no rejection.
+DELETE FROM coldfront.archive_watermark WHERE table_name = 'events';
+EXPLAIN (COSTS OFF, VERBOSE)
+  UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE status = 'x';
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Update on public._events
+   ->  Seq Scan on public._events
+         Output: 'Thu Jun 18 10:00:00 2026 UTC'::timestamp with time zone, ctid
+         Filter: (_events.status = 'x'::text)
+(4 rows)
+
+-- Cleanup. Unregister before dropping: the DDL hook blocks DROP of a
+-- registered tiered table/view.
+DELETE FROM coldfront.tiered_views;
+DROP VIEW public.events;
+DROP TABLE public._events;

--- a/extension/coldfront/test/sql/update_partition_key_blocked.sql
+++ b/extension/coldfront/test/sql/update_partition_key_blocked.sql
@@ -1,9 +1,10 @@
--- An UPDATE that assigns the partition column of a tiered view is blocked: such
--- a SET can move the row across the hot/cold cutoff, which the in-place rewrite
--- would lose silently (GitHub #20). The hook must ereport(ERROR) with SQLSTATE
--- 0A000 (ERRCODE_FEATURE_NOT_SUPPORTED) regardless of coldfront.allow_mixed_writes
--- and regardless of which tier the WHERE selects. Relocating the row is a separate
--- feature; until then the partition column is read-only via the view.
+-- STRICT mode (coldfront.allow_mixed_writes = off): an UPDATE that assigns the
+-- partition column of a tiered view is rejected. Such a SET can move the row
+-- across the hot/cold cutoff; with mixed writes off there is no atomic relocation
+-- to fall back on, so the hook must ereport(ERROR) with SQLSTATE 0A000
+-- (ERRCODE_FEATURE_NOT_SUPPORTED) regardless of which tier the WHERE selects.
+-- The permissive-mode counterpart (the actual cross-tier move) is covered by
+-- update_partition_key_move.sql; the live round-trip is ci/journey.sh.
 
 CREATE EXTENSION IF NOT EXISTS pg_duckdb;
 CREATE EXTENSION IF NOT EXISTS coldfront;
@@ -22,31 +23,27 @@ VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
 INSERT INTO coldfront.archive_watermark(table_name, cutoff_time)
 VALUES ('events', '2026-03-01'::timestamptz);
 
--- Permissive mode (default): a partition-column SET is still blocked, because
--- the move is not implemented and the dual-tier rewrite would lose the row.
-SET coldfront.allow_mixed_writes = on;
+-- Strict mode: no cross-tier move, so every partition-column SET is rejected.
+SET coldfront.allow_mixed_writes = off;
 
--- Cold→hot crossing (the #20 repro): blocked.
+-- Cold→hot crossing: rejected.
 UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE status = 'hot_orig';
 
--- Hot→cold crossing: blocked too (symmetric loss).
+-- Hot→cold crossing: rejected too (symmetric loss).
 UPDATE public.events SET ts = '2026-01-05 10:00:00+00' WHERE ts = '2026-04-01 12:00:00+00';
 
--- Same-tier constant SET is also blocked (blunt block; no per-value proof).
+-- Same-tier constant SET is also rejected (blunt block; no per-value proof).
 UPDATE public.events SET ts = '2026-04-02 12:00:00+00' WHERE ts = '2026-04-01 12:00:00+00';
 
--- Non-constant partition-column SET (could cross per-row): blocked.
+-- Non-constant partition-column SET (could cross per-row): rejected.
 UPDATE public.events SET ts = ts + interval '6 months' WHERE id = 1;
 
--- A tier-deterministic WHERE does not rescue a partition-column SET: blocked.
+-- A tier-deterministic WHERE does not rescue a partition-column SET: rejected.
 UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE ts = '2026-01-15 01:00:00+00';
 
--- Strict mode: same block.
-SET coldfront.allow_mixed_writes = off;
-UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE status = 'hot_orig';
-
 -- A SET that does NOT touch the partition column is unaffected (still routes by
--- WHERE tier — here hot, plain PG).
+-- WHERE tier — here hot, plain PG). This guards that the strict gate did not
+-- over-broaden into ordinary updates.
 UPDATE public.events SET status = 'ok' WHERE ts = '2026-04-01 12:00:00+00';
 
 -- _events: only the status update applied; every ts-changing statement errored.

--- a/extension/coldfront/test/sql/update_partition_key_move.sql
+++ b/extension/coldfront/test/sql/update_partition_key_move.sql
@@ -1,0 +1,61 @@
+-- PERMISSIVE mode (coldfront.allow_mixed_writes = on, the default): an UPDATE that
+-- assigns the partition column of a tiered view is rewritten into a single
+-- coldfront._cross_tier_move(...) call that relocates the matched rows across the
+-- hot/cold cutoff. White-box: we assert the rewrite shape via
+-- EXPLAIN VERBOSE — the rewritten statement is just the function call (no
+-- iceberg_scan in it, so the planner needs no Iceberg catalog). The live tier
+-- relocation is exercised in ci/journey.sh. v1 rejects, at parse-analyze, the move
+-- shapes the function does not support.
+
+CREATE EXTENSION IF NOT EXISTS pg_duckdb;
+CREATE EXTENSION IF NOT EXISTS coldfront;
+
+SET TIME ZONE 'UTC';
+-- White-box: checks the hooks' SQL/DDL, not Iceberg I/O. Real cold I/O is ci/journey.sh; see README.md.
+SET coldfront.warehouse = '';
+SET coldfront.lakekeeper_endpoint = '';
+
+CREATE TABLE public._events (id int, ts timestamptz, status text);
+CREATE VIEW public.events AS SELECT * FROM public._events;
+
+INSERT INTO coldfront.tiered_views(schema_name, relname, hot_table, iceberg_table, partition_col)
+VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
+INSERT INTO coldfront.archive_watermark(table_name, cutoff_time)
+VALUES ('events', '2026-03-01'::timestamptz);
+
+SET coldfront.allow_mixed_writes = on;
+
+-- (1) Constant new ts, WHERE on a non-partition column: the rewrite is one
+-- _cross_tier_move call carrying the deparsed WHERE and new-ts expression.
+EXPLAIN (COSTS OFF, VERBOSE)
+  UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE status = 'x';
+
+-- (2) Row-dependent new ts (ts + interval), tier-deterministic WHERE: same shape;
+-- the new-ts expression is the interval arithmetic over the partition column.
+EXPLAIN (COSTS OFF, VERBOSE)
+  UPDATE public.events SET ts = ts + interval '6 months' WHERE ts < '2026-02-01+00';
+
+-- (3) Rejections at parse-analyze (no tier write):
+-- a VOLATILE new value (re-evaluates per row → could split a row across tiers).
+UPDATE public.events SET ts = clock_timestamp() WHERE status = 'x';
+-- new value references a column other than the partition column.
+UPDATE public.events SET ts = make_timestamptz(2026, 6, 1, 0, 0, 0) + (id || ' days')::interval WHERE status = 'x';
+-- a multi-column SET that also moves the partition column.
+UPDATE public.events SET ts = '2026-06-18 10:00:00+00', status = 'y' WHERE status = 'x';
+-- RETURNING from a move (the cold tier cannot return rows).
+UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE status = 'x' RETURNING id;
+-- a WHERE that pulls in other tables / sub-queries: the cold tier is read in
+-- DuckDB, which can't correlate with Postgres tables, so it is rejected up front.
+UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE id IN (SELECT 1);
+
+-- Without a cutoff (nothing archived) a partition-column UPDATE is a plain hot
+-- UPDATE — no move, no rejection.
+DELETE FROM coldfront.archive_watermark WHERE table_name = 'events';
+EXPLAIN (COSTS OFF, VERBOSE)
+  UPDATE public.events SET ts = '2026-06-18 10:00:00+00' WHERE status = 'x';
+
+-- Cleanup. Unregister before dropping: the DDL hook blocks DROP of a
+-- registered tiered table/view.
+DELETE FROM coldfront.tiered_views;
+DROP VIEW public.events;
+DROP TABLE public._events;


### PR DESCRIPTION
An `UPDATE` that moves a tiered view's partition column across the hot/cold cutoff now relocates the row between tiers instead of stranding it (#20) or leaking the internal `_events` name (#21).

- Permissive mode (default) moves the row via `coldfront._cross_tier_move`; strict mode rejects it.
- Hot tier is plain PG; the cold tier is one `raw_query` (DELETE+INSERT = one Iceberg snapshot) under one bakery claim, the existing single-CAS writer shape, so no new protocol primitive.
- Tests: `update_partition_key_move` and `update_partition_key_blocked` (pg_regress), `story_cross_tier_move` (journey).

Fixes #20.
