### PR TITLE
fix: fail fast on permanent cutover errors instead of retrying

### DIFF
--- a/cmd/archiver/main.go
+++ b/cmd/archiver/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -1010,6 +1011,32 @@ func archiveCutover(ctx context.Context, conn *pgx.Conn, t *config.TableConfig,
 	return nil
 }
 
+// isRetryableCutover reports whether a Phase-4 (cutover_archive) failure is
+// worth retrying. cutover_archive's only transient failure by design is its
+// lock_timeout circuit breaker on the ACCESS EXCLUSIVE acquisition, which raises
+// lock_not_available (55P03) when a cold writer still holds the partition; the
+// lock_timeout is kept below deadlock_timeout so the cutover always yields that
+// way. Every other error is permanent (e.g. an inbound FK blocking DETACH,
+// 23503) — retrying only burns the backoff budget, so fail fast.
+func isRetryableCutover(err error) bool {
+	var pg *pgconn.PgError
+	return errors.As(err, &pg) && pg.Code == "55P03"
+}
+
+// cutoverFailHint returns actionable guidance for the well-known permanent
+// cutover failures. An inbound foreign key blocks DETACH (23503) because
+// archiving physically removes the rows from PostgreSQL (export to Iceberg,
+// then DETACH + DROP) and PG cannot enforce a foreign key against the cold tier.
+func cutoverFailHint(err error) string {
+	var pg *pgconn.PgError
+	if errors.As(err, &pg) && pg.Code == "23503" {
+		return fmt.Sprintf(" — inbound foreign key %q blocks the partition DETACH; "+
+			"archiving removes these rows from PostgreSQL, so the foreign key must be "+
+			"dropped before this table can be archived", pg.ConstraintName)
+	}
+	return ""
+}
+
 // runCutoverWithRetry runs Phase 3 (delta replay) + Phase 4 (atomic cutover)
 // under a 10-attempt retry harness with exponential backoff (100ms → 51.2s).
 // Phase 3 is idempotent so retries are safe; Phase 4 either commits everything
@@ -1045,6 +1072,12 @@ func runCutoverWithRetry(ctx context.Context, conn *pgx.Conn, t *config.TableCon
 			lastErr = err
 		}
 
+		// Only the lock-contention timeout (55P03) is transient. Anything else is
+		// permanent — fail fast instead of burning the ~51s backoff budget.
+		if !isRetryableCutover(lastErr) {
+			return fmt.Errorf("cutover %s failed (permanent, not retried): %w%s",
+				part.Name, lastErr, cutoverFailHint(lastErr))
+		}
 		log.Printf("cutover %s attempt %d failed after %s: %v (retry in %s)",
 			part.Name, attempt, time.Since(t4).Round(time.Millisecond), lastErr, backoff)
 		select {

--- a/cmd/archiver/main_test.go
+++ b/cmd/archiver/main_test.go
@@ -451,3 +451,34 @@ func TestDollarQuote(t *testing.T) {
 		assert.True(t, strings.HasPrefix(tag, "$cf") && strings.HasSuffix(tag, "$"), "tag shape $cf…$")
 	}
 }
+
+// TestIsRetryableCutover verifies that only the transient lock-timeout (55P03)
+// is retried and every other error (permanent, or non-Postgres) fails fast.
+func TestIsRetryableCutover(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"lock_not_available (55P03) is transient", &pgconn.PgError{Code: "55P03"}, true},
+		{"fk violation (23503) is permanent", &pgconn.PgError{Code: "23503"}, false},
+		{"deadlock (40P01) not retried — design yields via 55P03 first", &pgconn.PgError{Code: "40P01"}, false},
+		{"raise_exception (P0001) is permanent", &pgconn.PgError{Code: "P0001"}, false},
+		{"non-Postgres error fails fast", errors.New("boom"), false},
+		{"nil fails fast", nil, false},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, isRetryableCutover(c.err), c.name)
+	}
+}
+
+// TestCutoverFailHint verifies the 23503 hint names the blocking constraint and
+// that no hint is emitted for the transient timeout or non-Postgres errors.
+func TestCutoverFailHint(t *testing.T) {
+	fk := &pgconn.PgError{Code: "23503", ConstraintName: "event_logs_event_id_event_ts_fkey_1"}
+	h := cutoverFailHint(fk)
+	assert.Contains(t, h, "event_logs_event_id_event_ts_fkey_1", "names the blocking constraint")
+	assert.Contains(t, h, "must be dropped", "gives actionable guidance")
+	assert.Empty(t, cutoverFailHint(&pgconn.PgError{Code: "55P03"}), "no hint for the transient lock timeout")
+	assert.Empty(t, cutoverFailHint(errors.New("boom")), "no hint for non-Postgres errors")
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -133,6 +133,30 @@ Iceberg rows older than it. The data lifecycle is **hot → `hot_period` →
 cold → `retention_period` → gone**; omit `retention_period` to keep cold
 data forever.
 
+### Inbound foreign keys
+
+A tiered table cannot be the target of an enforced foreign key from
+another table over its archivable range. Archiving physically removes
+the rows from PostgreSQL (export to Iceberg, then `DETACH` + `DROP` the
+partition), and PostgreSQL cannot enforce a foreign key against the cold
+tier. So the `DETACH` is refused (SQLSTATE 23503) and the archiver fails
+fast, naming the blocking constraint.
+
+This is inherent, not an edge case: referencing rows rarely have a
+hot-only lifecycle. They usually outlive the partition they point at, so
+the foreign key still pins those rows in PostgreSQL by the time the
+partition ages into the cold tier.
+
+The foreign key is fundamentally incompatible with archiving the rows it
+references, so before archiving such a table, drop it:
+
+```sql
+ALTER TABLE event_logs DROP CONSTRAINT event_logs_events_fkey;
+```
+
+Better still, do not point an enforced foreign key at a tiered table over
+its archivable range in the first place.
+
 ### 2-level (LIST → RANGE) tiered tables
 
 A table partitioned `LIST (region) → RANGE (ts)` can be tiered too - the


### PR DESCRIPTION
The archiver retried every cutover failure 10x (~51s), so a permanent error like an inbound FK blocking DETACH (23503) burned the whole backoff budget before failing. Now it retries only the transient lock-timeout (55P03) and fails fast on everything else, with a message naming the blocking constraint. Also documents why a tiered table can't be an enforced FK target over its archivable range.

Fixes #33