### PR TITLE
fix: serialize same-node cold writers with a node-local advisory lock

### DIFF
--- a/ci/journey.sh
+++ b/ci/journey.sh
@@ -630,8 +630,8 @@ EOSQL
 # require_compactor — stories 6d/6e drive the standalone Go compactor (cmd/compactor,
 # a separate iceberg-go module). Assert its binary is present before they run: a missing
 # "$COMPACTOR" otherwise gets captured into the dry-run output as "No such file or
-# directory" and reported as "nothing to compact", masking the real cause (issue #17 —
-# 6d/6e ran against a vanilla.sh that never built the compactor).
+# directory" and reported as "nothing to compact", masking the real cause:
+# 6d/6e ran against a vanilla.sh that never built the compactor.
 require_compactor() {
     [ -x "$COMPACTOR" ] && return 0
     fail "compactor binary not found/executable at $COMPACTOR — build it with 'make compactor'; stories 6d/6e require it"
@@ -897,7 +897,7 @@ story_blocks() {
 }
 
 # ───────────────────────────────────────────────────────────────────────────
-# Story — Extension dependency (#32). coldfront.control declares
+# Story — Extension dependency. coldfront.control declares
 # requires = 'pg_duckdb', so on a database without pg_duckdb, CREATE EXTENSION
 # coldfront is rejected up front ("required extension ... is not installed")
 # instead of failing later at runtime with schema "duckdb" not existing. Use a
@@ -905,7 +905,7 @@ story_blocks() {
 # what template1 carries.
 # ───────────────────────────────────────────────────────────────────────────
 story_ext_requires() {
-    step "Extension dependency: CREATE EXTENSION coldfront without pg_duckdb is rejected (#32)"
+    step "Extension dependency: CREATE EXTENSION coldfront without pg_duckdb is rejected"
     q "$HOST" "DROP DATABASE IF EXISTS cf_dep_check;"
     q "$HOST" "CREATE DATABASE cf_dep_check;"
     docker exec -e PGUSER="$CF_DBUSER" -e PGDATABASE=cf_dep_check "$HOST" "$CF_PSQL" -tA \
@@ -1135,6 +1135,45 @@ story_mesh() {
         "$(cat /tmp/journey-ra.* 2>/dev/null | grep -cEi 'error|conflict|409')"
     assert_eq "concurrent cross-node cold writers both landed (R-A bakery, no 409)" "2" "$(q "$HOST" "SELECT count(*) FROM iceonly WHERE status='ra';")"
     rm -f /tmp/journey-ra.* 2>/dev/null
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Story 12b — MULTIPLE concurrent cold writers PER NODE, on >=2 nodes, to the
+# SAME iceberg table. Unlike story_mesh (1 writer/node), this leaves >1
+# same-node claim outstanding per node at once; the node-local advisory lock in
+# _claim_iceberg_lock serializes them so the cross-node bakery sees one claim
+# per node and no commit hits a Lakekeeper 409.
+# ───────────────────────────────────────────────────────────────────────────
+story_mesh_multiwriter() {
+    step "12b. Mesh: multiple cold writers PER NODE, cross-node, same table"
+    local PARR; read -ra PARR <<< "$PEERS"
+    [ "${#PARR[@]}" -ge 1 ] || { fail "mesh: no --peers given"; return; }
+    local p1="${PARR[0]}" N=5 k pids=() tbl
+    [ "$MODE" = tiered ] && tbl=events || tbl=iceonly
+    rm -f /tmp/journey-mw.* 2>/dev/null
+    # Fire N writers on db1 AND N on the peer, all at once, all cold-routed to the
+    # same table: decoupled writes straight to iceonly, tiered writes a cold-dated
+    # row to events (ts before the cutoff, so it lands in the cold tier).
+    for k in $(seq 1 "$N"); do
+        local a b
+        if [ "$MODE" = tiered ]; then
+            a="INSERT INTO events (ts,status,data) VALUES (date_trunc('month',now()) - interval '4 months' + interval '$k days','mw','{}');"
+            b="INSERT INTO events (ts,status,data) VALUES (date_trunc('month',now()) - interval '4 months' + interval '$k days 12 hours','mw','{}');"
+        else
+            a="INSERT INTO iceonly VALUES ($((7000+k)),date_trunc('month',now()) + interval '3 months' + interval '$k hours','mw','{}');"
+            b="INSERT INTO iceonly VALUES ($((8000+k)),date_trunc('month',now()) + interval '3 months' + interval '$k hours 30 minutes','mw','{}');"
+        fi
+        q "$HOST" "$a" >"/tmp/journey-mw.a$k" 2>&1 &
+        pids+=("$!")
+        q "$p1"   "$b" >"/tmp/journey-mw.b$k" 2>&1 &
+        pids+=("$!")
+    done
+    for k in "${pids[@]}"; do wait "$k"; done
+    assert_eq "no multi-writer-per-node cross-node cold writer errored (no 409)" "0" \
+        "$(cat /tmp/journey-mw.* 2>/dev/null | grep -cEi 'error|conflict|409')"
+    assert_eq "all $((2 * N)) multi-writer-per-node cross-node cold writes landed" "$((2 * N))" \
+        "$(q "$HOST" "SELECT count(*) FROM $tbl WHERE status='mw';")"
+    rm -f /tmp/journey-mw.* 2>/dev/null
 }
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -1644,14 +1683,14 @@ story_partitioner_idmode() {
 
 # ───────────────────────────────────────────────────────────────────────────
 # Story — partitioner: TWO independent flat tables in the SAME schema (the real-
-# world case — issue #11). Before the table-scoped-naming fix both tables
+# world case). Before the table-scoped-naming fix both tables
 # generated the same leaf names (p_YYYY_MM); the second's CREATE … IF NOT EXISTS
 # silently no-op'd, leaving it partition-less while the run still reported
 # success. Assert BOTH tables get their own (table-scoped) partitions, the leaf
 # names are prefixed per table, and a fresh row lands in each.
 # ───────────────────────────────────────────────────────────────────────────
 story_partitioner_multitable() {
-    step "Partitioner multi-table: two flat tables, one schema, both partitioned (issue #11)"
+    step "Partitioner multi-table: two flat tables, one schema, both partitioned"
     local dsn="host=${DB_IP} port=5432 dbname=coldfront user=coldfront password=coldfront sslmode=disable"
     printf 'postgres: { dsn: "%s" }\n' "$dsn" > /tmp/journey-mt.yaml
     q "$HOST" "CREATE SCHEMA IF NOT EXISTS mt;
@@ -1681,26 +1720,26 @@ story_partitioner_multitable() {
 }
 
 # ───────────────────────────────────────────────────────────────────────────
-# Story — issue #12: after the archiver's first-run swap (events → _events, with
+# Story — after the archiver's first-run swap (events → _events, with
 # a unified view left in events' place) the standalone partitioner must premake
 # against the real partitioned table (_events), not the view. The configured /
 # registered source name is still "events"; reconcileTable resolves it to the
 # "_"+name partitioned relation before building the spec. Pre-fix the partitioner
-# targeted the view and aborted on the issue #11 verify-attach guard ("not
+# targeted the view and aborted on the verify-attach guard ("not
 # attached … different parent"); post-fix it premakes the forward window straight
 # onto _events.
 # ───────────────────────────────────────────────────────────────────────────
 story_partitioner_after_swap() {
-    step "Partitioner after first-run swap: premakes onto _events, not the view (issue #12)"
+    step "Partitioner after first-run swap: premakes onto _events, not the view"
     # Precondition (set up by story_provision_tiered): events is a VIEW now and
     # _events is the partitioned hot table.
-    assert_eq "issue #12: precondition — events is a view"       "v" "$(q "$HOST" "SELECT relkind FROM pg_class WHERE relname='events'  AND relnamespace='public'::regnamespace;")"
-    assert_eq "issue #12: precondition — _events is partitioned" "p" "$(q "$HOST" "SELECT relkind FROM pg_class WHERE relname='_events' AND relnamespace='public'::regnamespace;")"
+    assert_eq "precondition — events is a view"       "v" "$(q "$HOST" "SELECT relkind FROM pg_class WHERE relname='events'  AND relnamespace='public'::regnamespace;")"
+    assert_eq "precondition — _events is partitioned" "p" "$(q "$HOST" "SELECT relkind FROM pg_class WHERE relname='_events' AND relnamespace='public'::regnamespace;")"
     local dsn="host=${DB_IP} port=5432 dbname=coldfront user=coldfront password=coldfront sslmode=disable"
     # Drive the partitioner off the post-swap source name "events" with a wide
     # future window (6) so it premakes months the archiver (premake 3) did not —
     # proving it acted on _events. retention 60 months drops nothing.
-    cat > /tmp/journey-issue12.yaml <<EOF
+    cat > /tmp/journey-partitioner.yaml <<EOF
 postgres:
   dsn: "${dsn}"
 archiver:
@@ -1710,30 +1749,30 @@ archiver:
       retention_period: "60 months"
       future_partitions: 6
 EOF
-    if ! "$PARTITIONER" --config /tmp/journey-issue12.yaml >/tmp/journey-issue12.log 2>&1; then
-        fail "issue #12: partitioner run failed (pre-fix it targets the view)"; tail -8 /tmp/journey-issue12.log; return
+    if ! "$PARTITIONER" --config /tmp/journey-partitioner.yaml >/tmp/journey-partitioner.log 2>&1; then
+        fail "partitioner run failed"; tail -8 /tmp/journey-partitioner.log; return
     fi
-    # The fix resolves events → _events, so the reconcile is logged against _events.
-    if grep -q "\[_events\] reconciled" /tmp/journey-issue12.log; then
-        pass "issue #12: partitioner reconciled _events (resolved past the view)"
+    # The partitioner resolves events → _events, so the reconcile is logged against _events.
+    if grep -q "\[_events\] reconciled" /tmp/journey-partitioner.log; then
+        pass "partitioner reconciled _events (resolved past the view)"
     else
-        fail "issue #12: reconcile did not target _events"; tail -8 /tmp/journey-issue12.log
+        fail "reconcile did not target _events"; tail -8 /tmp/journey-partitioner.log
     fi
-    # And it never trips the verify-attach guard that the pre-fix view target hits.
-    if grep -q "different parent" /tmp/journey-issue12.log; then
-        fail "issue #12: partitioner tripped the verify-attach guard (still targeting the view)"; tail -8 /tmp/journey-issue12.log
+    # And it never trips the verify-attach guard that targeting the view would hit.
+    if grep -q "different parent" /tmp/journey-partitioner.log; then
+        fail "partitioner tripped the verify-attach guard (still targeting the view)"; tail -8 /tmp/journey-partitioner.log
     else
-        pass "issue #12: no verify-attach error (did not touch the view)"
+        pass "no verify-attach error (did not touch the view)"
     fi
     # Behavioral proof: the +5-month leaf (beyond the archiver's premake window) is
     # attached to _events, the real partitioned table — not orphaned or erroring.
     local fut; fut="events_p_$(date -u -d "$(date -u +%Y-%m-01) +5 months" +%Y_%m)"
-    assert_eq "issue #12: +5mo leaf $fut premade onto _events" "1" \
+    assert_eq "+5mo leaf $fut premade onto _events" "1" \
         "$(q "$HOST" "SELECT count(*) FROM pg_inherits i JOIN pg_class c ON c.oid=i.inhrelid WHERE i.inhparent='public._events'::regclass AND c.relname='$fut';")"
 }
 
 # ───────────────────────────────────────────────────────────────────────────
-# Story — issue #14: coldfront.partition_config is ONE shared table holding both
+# Story — coldfront.partition_config is ONE shared table holding both
 # archiver-owned (tiered: hot_period set) and partitioner-owned (partition-only:
 # hot_period NULL) rows. Each binary must load only the rows it owns, scoped in
 # SQL by hot_period. Pre-fix the shared loader took every enabled row, so the
@@ -1745,7 +1784,7 @@ EOF
 # idmode_check) and the cleanup keeps the shared config clean for later stories.
 # ───────────────────────────────────────────────────────────────────────────
 story_partition_config_ownership() {
-    step "Shared partition_config: each binary loads only the rows it owns (issue #14)"
+    step "Shared partition_config: each binary loads only the rows it owns"
     local dsn="host=${DB_IP} port=5432 dbname=coldfront user=coldfront password=coldfront sslmode=disable"
     q "$HOST" "CREATE SCHEMA IF NOT EXISTS own;
                CREATE TABLE IF NOT EXISTS own.po  (id bigint GENERATED ALWAYS AS IDENTITY, ts timestamptz NOT NULL, PRIMARY KEY (id, ts)) PARTITION BY RANGE (ts);
@@ -1757,26 +1796,26 @@ story_partition_config_ownership() {
     # so we assert per-table ownership, NOT an absolute "loaded N" count).
     "$PARTITIONER" register --dsn "$dsn" --schema own --table po   --period monthly --retention "60 months" >/tmp/journey-own-po-reg.log   2>&1
     "$ARCHIVER"    register --dsn "$dsn" --schema own --table tier --period monthly --hot-period "1 month" --retention "60 months" >/tmp/journey-own-tier-reg.log 2>&1
-    assert_eq "issue #14: partition-only row owned by partitioner (hot_period NULL)" "1" \
+    assert_eq "partition-only row owned by partitioner (hot_period NULL)" "1" \
         "$(q "$HOST" "SELECT count(*) FROM coldfront.partition_config WHERE schema_name='own' AND table_name='po'   AND hot_period IS NULL;")"
-    assert_eq "issue #14: tiered row owned by archiver (hot_period set)"             "1" \
+    assert_eq "tiered row owned by archiver (hot_period set)"             "1" \
         "$(q "$HOST" "SELECT count(*) FROM coldfront.partition_config WHERE schema_name='own' AND table_name='tier' AND hot_period IS NOT NULL;")"
 
     # Archiver run: processes its tiered row (own.tier), never the partitioner's
     # partition-only row (own.po), and no longer aborts on a foreign row.
     "$ARCHIVER" --config /tmp/journey-archiver.yaml >/tmp/journey-own-arch.log 2>&1 || true
     if grep -q "hot_period is required in tiered mode" /tmp/journey-own-arch.log; then
-        fail "issue #14: archiver still choked on the partition-only row"; tail -5 /tmp/journey-own-arch.log
+        fail "archiver still choked on the partition-only row"; tail -5 /tmp/journey-own-arch.log
     else
-        pass "issue #14: archiver did not choke on the partition-only row"
+        pass "archiver did not choke on the partition-only row"
     fi
     # Per-table logs use the bare source-table name ([tier] / [po]); own.tier and
     # own.po are unique here so the substrings are unambiguous.
-    assert_contains "issue #14: archiver processed its own tiered table" "[tier]" "$(cat /tmp/journey-own-arch.log)"
+    assert_contains "archiver processed its own tiered table" "[tier]" "$(cat /tmp/journey-own-arch.log)"
     if grep -q "\[po\]" /tmp/journey-own-arch.log; then
-        fail "issue #14: archiver touched the partitioner's row (po)"; tail -5 /tmp/journey-own-arch.log
+        fail "archiver touched the partitioner's row (po)"; tail -5 /tmp/journey-own-arch.log
     else
-        pass "issue #14: archiver ignored the partitioner's row (po)"
+        pass "archiver ignored the partitioner's row (po)"
     fi
 
     # Partitioner run: reconciles its partition-only row (own.po), never the
@@ -1784,15 +1823,15 @@ story_partition_config_ownership() {
     printf 'postgres: { dsn: "%s" }\n' "$dsn" > /tmp/journey-own-part.yaml
     "$PARTITIONER" --config /tmp/journey-own-part.yaml >/tmp/journey-own-part.log 2>&1 || true
     if grep -q "only valid in tiered mode" /tmp/journey-own-part.log; then
-        fail "issue #14: partitioner still choked on the tiered row"; tail -5 /tmp/journey-own-part.log
+        fail "partitioner still choked on the tiered row"; tail -5 /tmp/journey-own-part.log
     else
-        pass "issue #14: partitioner did not choke on the tiered row"
+        pass "partitioner did not choke on the tiered row"
     fi
-    assert_contains "issue #14: partitioner reconciled its own partition-only table" "[po] reconciled" "$(cat /tmp/journey-own-part.log)"
+    assert_contains "partitioner reconciled its own partition-only table" "[po] reconciled" "$(cat /tmp/journey-own-part.log)"
     if grep -q "\[tier\]" /tmp/journey-own-part.log; then
-        fail "issue #14: partitioner touched the archiver's row (tier)"; tail -5 /tmp/journey-own-part.log
+        fail "partitioner touched the archiver's row (tier)"; tail -5 /tmp/journey-own-part.log
     else
-        pass "issue #14: partitioner ignored the archiver's row (tier)"
+        pass "partitioner ignored the archiver's row (tier)"
     fi
 
     # Clean up so the SHARED coldfront.partition_config stays clean for later stories.
@@ -1871,7 +1910,7 @@ if [ "$MODE" = "tiered" ]; then
     story_partitioner_multitable
     story_partitioner_after_swap
     story_register_cli
-    story_partition_config_ownership   # issue #14: each binary loads only its own rows
+    story_partition_config_ownership   # each binary loads only its own rows
 else
     story_provision_decoupled
     story_decoupled_crud
@@ -1880,6 +1919,7 @@ else
     story_decoupled_ryw
 fi
 [ "$MESH" = 1 ] && [ "$MODE" = decoupled ] && story_mesh   # tiered+mesh runs story_mesh_tiered (above)
+[ "$MESH" = 1 ] && story_mesh_multiwriter   # >1 cold writer/node cross-node (tiered: events, decoupled: iceonly)
 [ -n "$STANDBY" ]    && story_standby_reads
 
 summary

--- a/docs/formal/Bakery_v2.cfg
+++ b/docs/formal/Bakery_v2.cfg
@@ -9,6 +9,8 @@
 
 CONSTANTS
   Writers       = {w1, w2, w3}
+  NodeParts     = {{w1}, {w2}, {w3}}
+  SameNodeLock  = TRUE
   MaxTickets    = 6
   MaxIcebergLen = 5
   MaxCrashes    = 0

--- a/docs/formal/Bakery_v2.tla
+++ b/docs/formal/Bakery_v2.tla
@@ -8,13 +8,13 @@
 (* mutual exclusion algorithm to compensate for that asymmetry.            *)
 (*                                                                         *)
 (* Protocol (Ricart-Agrawala):                                             *)
-(*   1. Writer inserts claim into its own claims[w].  Replicates via Apply *)
-(*      (async).                                                            *)
-(*   2. Each peer, on applying my claim, DECIDES then WRITES (two steps,   *)
-(*      faithful to the non-atomic SQL -- see SafeAcks):                   *)
+(*   1. Writer inserts claim into its NODE's claims view.  Replicates via  *)
+(*      Apply (async).                                                     *)
+(*   2. Each peer node, on applying the claim, DECIDES then WRITES (two    *)
+(*      steps, faithful to the non-atomic SQL -- see SafeAcks):            *)
 (*       - own pending claim with SMALLER ticket -> DEFER the ack          *)
 (*         (queue in `deferred`); otherwise ack immediately.               *)
-(*   3. Writer waits until every alive peer has acked.                     *)
+(*   3. Writer waits until every alive peer node has acked.                *)
 (*   4. Writer proceeds to Decide (the CAS, under the held claim).         *)
 (*   5. On release: FORWARD the deferred acks (deferred -> acks) then      *)
 (*      DELETE them -- also two steps.                                     *)
@@ -29,6 +29,19 @@
 (*   SELECT ... FOR UPDATE on the claim row in coldfront._on_claim_apply,  *)
 (*   so it never defers behind a released claim.  R-A is unchanged; only   *)
 (*   the implementation's atomicity differs.                              *)
+(*                                                                         *)
+(* SAME-NODE SERIALIZATION -- modelled directly by NodeParts + SameNodeLock.*)
+(* NodeParts partitions writers into nodes (many writers MAY share one), so *)
+(* claims are keyed by NODE and a writer clears the bakery only when BOTH   *)
+(* smallest active claim on its own node (clause a) AND acked by every peer *)
+(* node (clause b, Ricart-Agrawala). SameNodeLock models                   *)
+(* coldfront._claim_iceberg_lock: TRUE holds a node-local advisory xact     *)
+(* lock so at most one same-node writer is in the bakery at a time. With it *)
+(* FALSE, two same-node claims a1<a2 below a peer's b1 coexist and the      *)
+(* ack-forward on a1's Release clears b1 while a2 still holds -- a and b     *)
+(* both commit, racing the CAS. Bakery_v2_samenode_race.cfg proves that     *)
+(* violates NoLakekeeperConflict; Bakery_v2_samenode.cfg proves the lock    *)
+(* restores safety by collapsing it to the one-claim-per-node topology.     *)
 (*                                                                         *)
 (* Properties:                                                             *)
 (*   SAFETY (hold under both SafeAcks values):                            *)
@@ -94,6 +107,10 @@
 EXTENDS Naturals, Sequences, FiniteSets, TLC
 
 CONSTANTS Writers,
+          NodeParts,      \* partition of Writers into nodes -- each element is the
+                          \* set of writers on one node (a PG instance runs many
+                          \* concurrent cold sessions). All-singletons (one writer
+                          \* per node) reduces to v1's topology.
           MaxTickets,
           MaxIcebergLen,
           MaxCrashes,
@@ -105,7 +122,7 @@ CONSTANTS Writers,
                           \* TRUE = patched deployment. AsyncParquet=TRUE with
                           \* RestampPatch=FALSE reproduces the pre-patch 409 race that
                           \* makes the patch mandatory for the async ordering.
-          SafeAcks        \* TRUE = the SAFE implementation of R-A's defer/ack: the
+          SafeAcks,       \* TRUE = the SAFE implementation of R-A's defer/ack: the
                           \* defer is written atomically with a re-check of R-A's own
                           \* rule (the smaller-ticket claim must STILL be held), so a
                           \* deferral is never written behind a released claim, and the
@@ -113,36 +130,53 @@ CONSTANTS Writers,
                           \* (decide, then separately write) that drops acks — the bug.
                           \* The PROTOCOL (R-A) is identical either way; only the
                           \* implementation's atomicity differs.
+          SameNodeLock    \* coldfront._claim_iceberg_lock's node-local advisory xact
+                          \* lock: TRUE = at most ONE cold writer per node is in the
+                          \* bakery at a time (the deployment fix). FALSE = same-node
+                          \* writers race; with two same-node claims a1<a2 both below a
+                          \* peer's b1, node A defers b1 behind its SMALLEST same-node
+                          \* claim (a1) and, on a1's Release, forwards A's ack for b1
+                          \* WITHOUT re-deferring behind a2 (still held, still < b1) —
+                          \* so a2 and b1 both clear the bakery and race the CAS.
 
 ASSUME /\ Writers # {}
+       /\ Writers = UNION NodeParts
+       /\ \A S, T \in NodeParts : S = T \/ S \cap T = {}
        /\ MaxTickets    \in Nat /\ MaxTickets    >= Cardinality(Writers)
        /\ MaxIcebergLen \in Nat /\ MaxIcebergLen >= 1
        /\ MaxCrashes    \in Nat /\ MaxCrashes    <= Cardinality(Writers)
        /\ AsyncParquet  \in BOOLEAN
        /\ RestampPatch  \in BOOLEAN
        /\ SafeAcks      \in BOOLEAN
+       /\ SameNodeLock  \in BOOLEAN
 
 NoTicket == 0
 NoSnap   == 0
+Nodes    == NodeParts
+Nd(w)    == CHOOSE nd \in NodeParts : w \in nd
+MinT(S)  == CHOOSE m \in S : \A x \in S : m <= x
 
 (*--algorithm Bakery_v2
 variables
   next_ticket = 1,
 
-  \* Per-writer LOCAL view of coldfront.claims.  Asymmetric apply is
-  \* the realistic spock behaviour; R-A's deferred-ack mechanism
-  \* compensates by gating min-equivalent on per-peer acks.
-  claims = [w \in Writers |-> {}],
+  \* Per-NODE LOCAL view of coldfront.claims.  Writers on the same node
+  \* share one view (one PG instance, one claims table); asymmetric apply
+  \* across nodes is the realistic spock behaviour, and R-A's deferred-ack
+  \* mechanism compensates by gating min-equivalent on per-peer-node acks.
+  claims = [nd \in Nodes |-> {}],
 
-  \* Acks received per ticket.  A pair <<t, p>> in `acks` means peer p
-  \* has acked the claim with ticket t.  Models coldfront.claim_acks
+  \* Acks received per ticket.  A pair <<t, nd>> in `acks` means peer NODE
+  \* nd has acked the claim with ticket t.  Models coldfront.claim_acks
   \* (on the originator side, fully populated via spock replication of
   \* peer-emitted ack rows).
   acks = {},
 
-  \* Deferred acks: pair <<p, t>> means peer p has queued an ack-for-
-  \* ticket-t that it'll fire when p releases its own pending claim.
-  \* Models coldfront.deferred_acks on each peer.
+  \* Deferred acks: a triple <<nd, t, behind>> means node nd queued an
+  \* ack-for-ticket-t that it fires when the same-node claim `behind` is
+  \* released.  Models coldfront.deferred_acks: the code keys the deferral
+  \* to the SMALLEST same-node pending claim, so a `behind` that releases
+  \* while a larger same-node claim below t still holds forwards too early.
   deferred = {},
 
   iceberg = << [w |-> 0, t |-> 0, parent |-> 0, kind |-> "prime"] >>,
@@ -155,21 +189,32 @@ define
   Live(w)        == ~ crashed[w]
   IcebergHead    == Len(iceberg)
 
-  \* All alive peers (excluding self) have acked ticket t.  The
-  \* `~ Live(p)` shortcut is the failure-detector clause: a crashed
-  \* peer's missing ack does not block progress.  In the real system
-  \* this is implemented by combining the claim_acks table with a
-  \* heartbeat-staleness check (pg_stat_replication.reply_time) so
-  \* dead peers are treated as already-acked.  This closes the
-  \* classic R-A weakness where a crashed peer's deferred ack would
-  \* strand survivors forever.
-  AlivePeersHaveAcked(self, t) ==
-    \A p \in Writers :
-      p = self \/ ~ Live(p) \/ <<t, p>> \in acks
+  \* A node is alive if any of its writers is alive (a node is one PG
+  \* instance; its concurrent cold sessions crash with it).  A node `nd` is
+  \* the set of its writers.
+  NodeLive(nd)   == \E w \in nd : ~ crashed[w]
 
-  \* Tickets this writer has queued deferred acks for.
-  MyDeferredTickets(self) ==
-    { t : <<p, t>> \in {x \in deferred : x[1] = self} }
+  \* Clause (b) of R-A: every alive peer NODE (excluding my own) has acked
+  \* ticket t.  The `~ NodeLive(nd)` shortcut is the failure-detector
+  \* clause: a crashed node's missing ack does not block progress.  In the
+  \* real system this combines claim_acks with a heartbeat-staleness check
+  \* (pg_stat_replication.reply_time) so dead nodes are treated as
+  \* already-acked -- closing the classic R-A weakness where a crashed
+  \* peer's deferred ack would strand survivors forever.
+  AllPeerNodesAcked(self, t) ==
+    \A nd \in Nodes :
+      nd = Nd(self) \/ ~ NodeLive(nd) \/ <<t, nd>> \in acks
+
+  \* Clause (a): no OTHER active claim on my own node has a smaller ticket
+  \* -- same-node writers commit smallest-ticket-first.  Vacuous when one
+  \* writer per node (there is no other same-node claim).
+  SmallestOnMyNode(self, t) ==
+    ~ \E x \in claims[Nd(self)] : x.n = Nd(self) /\ x.w # self /\ x.t < t
+
+  \* Peer-node deferrals queued BEHIND my claim (ticket t) that my Release
+  \* forwards into acks.
+  MyForwardable(self, t) ==
+    { d \in deferred : d[1] = Nd(self) /\ d[3] = t }
 
   \* Safety properties (all HOLD in v2).
   NoLakekeeperConflict ==
@@ -181,7 +226,7 @@ define
         ~ \E i \in 1..Len(iceberg) : iceberg[i].w = w
 
   UniqueTickets ==
-    \A p, q \in Writers :
+    \A p, q \in Nodes :
       \A x \in claims[p], y \in claims[q] :
         x.t = y.t => x.w = y.w
 
@@ -227,21 +272,28 @@ begin
     end if;
 
   BeginClaim:
-    \* Insert claim into my local view.  Async replication via Applier.
-    \* No sync rep — R-A's ack barrier replaces it.
+    \* Insert claim into my NODE's local view.  Async replication via Applier.
+    \* No sync rep — R-A's ack barrier replaces it.  The SameNodeLock guard is
+    \* coldfront._claim_iceberg_lock's node-local advisory xact lock: block
+    \* while another writer on my node is mid-claim, so at most one same-node
+    \* claim is in the bakery at a time (node-local, so instant/synchronous).
     await Live(self) /\ \E p \in Writers : p # self /\ Live(p);
     await next_ticket <= MaxTickets;
+    await (~ SameNodeLock)
+          \/ ~ \E x \in claims[Nd(self)] : x.n = Nd(self) /\ x.w # self;
     my_ticket := next_ticket;
     next_ticket := next_ticket + 1;
-    claims[self] := claims[self] \cup
-                    {[w |-> self, t |-> my_ticket, n |-> self]};
+    claims[Nd(self)] := claims[Nd(self)] \cup
+                        {[w |-> self, t |-> my_ticket, n |-> Nd(self)]};
 
   WaitAcks:
-    \* Wait for every alive peer to ack.  Peers ack either immediately
-    \* (no smaller-ticket pending claim there) or via the deferred-drain
-    \* fired by the smaller-ticket holder at its Release.  Either way,
-    \* "all acks in" == "I'm at the head of the line."  No min-spin.
-    await Live(self) /\ AlivePeersHaveAcked(self, my_ticket);
+    \* Clear the bakery when I am BOTH the smallest active claim on my own node
+    \* (clause a) AND acked by every alive peer node (clause b).  Peer nodes ack
+    \* either immediately (no smaller-ticket pending claim there) or via the
+    \* deferred-drain fired by the smaller-ticket holder at its Release.
+    await Live(self)
+          /\ SmallestOnMyNode(self, my_ticket)
+          /\ AllPeerNodesAcked(self, my_ticket);
 
   Prepare:
     \* Capture the parent_snapshot_id the Lakekeeper CAS asserts against:
@@ -283,24 +335,27 @@ begin
     end either;
 
   Release:
-    \* The C XactCallback's claim DELETE: remove my claim from every local view.
+    \* The C XactCallback's claim DELETE: remove my claim from every node view.
     await Live(self);
-    claims := [p \in Writers |->
-                claims[p] \ {[w |-> self, t |-> my_ticket, n |-> self]}];
+    claims := [nd \in Nodes |->
+                claims[nd] \ {[w |-> self, t |-> my_ticket, n |-> Nd(self)]}];
 
   DrainForward:
     \* _on_claim_release step 1 (forward): INSERT claim_acks SELECT … FROM
-    \* deferred_acks WHERE pending = my ticket.  A deferral the Applier writes
-    \* AFTER this read but BEFORE DrainDelete is NOT seen here.
+    \* deferred_acks WHERE pending = my ticket — forward the peer-node acks
+    \* queued behind MY claim.  A deferral the Applier writes AFTER this read
+    \* but BEFORE DrainDelete is NOT seen here.  With SameNodeLock FALSE this
+    \* is the same-node race: if a same-node claim below the deferred ticket
+    \* still holds, forwarding here clears that peer node too early.
     await Live(self);
-    acks := acks \cup { <<t, self>> : t \in MyDeferredTickets(self) };
+    acks := acks \cup { <<d[2], Nd(self)>> : d \in MyForwardable(self, my_ticket) };
 
   DrainDelete:
-    \* _on_claim_release step 2 (the SEPARATE DELETE): delete my deferrals —
-    \* including any inserted in the DrainForward→here window, which were never
-    \* forwarded.  Non-atomic forward-then-delete = the silently dropped ack.
+    \* _on_claim_release step 2 (the SEPARATE DELETE): delete the deferrals I
+    \* forwarded — including any inserted in the DrainForward→here window, which
+    \* were never forwarded.  Non-atomic forward-then-delete = the dropped ack.
     await Live(self);
-    deferred := { x \in deferred : x[1] # self };
+    deferred := { x \in deferred : ~ (x[1] = Nd(self) /\ x[3] = my_ticket) };
 end process;
 
 (*-----------------------------------------------------------------------*)
@@ -308,21 +363,28 @@ end process;
 (* At apply time, the R-A defer-or-ack decision is made.                 *)
 (*-----------------------------------------------------------------------*)
 fair process Applier = "applier"
-variables ap_dst = NoTicket, ap_ct = NoTicket, ap_defer = FALSE;
+variables ap_dst = NoTicket, ap_ct = NoTicket, ap_defer = FALSE,
+          ap_behind = NoTicket;
 begin
   ApplyLoop:
     while TRUE do
-      \* ApplyDecide — apply one claim into dst's local view and DECIDE, under the
-      \* read snapshot, whether to defer or ack.  Mirrors _on_claim_apply reading
-      \* coldfront.claims (the shared advisory lock is dropped after this SELECT)
-      \* and CHOOSING defer-vs-ack — but NOT yet writing it.
-      with src \in Writers, dst \in Writers do
-        await dst # src /\ Live(dst);
-        with c \in { x \in claims[src] : x \notin claims[dst] /\ x.w = src } do
+      \* ApplyDecide — apply one claim from a src NODE into a dst NODE's local
+      \* view and DECIDE, under the read snapshot, whether to defer or ack.
+      \* Mirrors _on_claim_apply reading coldfront.claims (the shared advisory
+      \* lock is dropped after this SELECT) and CHOOSING defer-vs-ack — but NOT
+      \* yet writing it.  ap_behind is the smallest same-node pending claim the
+      \* deferral keys to (ORDER BY ticket LIMIT 1 in the SQL).
+      with src \in Nodes, dst \in Nodes do
+        await dst # src /\ NodeLive(dst);
+        with c \in { x \in claims[src] : x \notin claims[dst] /\ x.n = src } do
           claims[dst] := claims[dst] \cup { c };
           ap_dst   := dst;
           ap_ct    := c.t;
-          ap_defer := \E own \in claims[dst] : own.w = dst /\ own.t < c.t;
+          ap_defer := \E own \in claims[dst] : own.n = dst /\ own.t < c.t;
+          ap_behind := IF \E own \in claims[dst] : own.n = dst /\ own.t < c.t
+                         THEN MinT({ own.t : own \in
+                               {y \in claims[dst] : y.n = dst /\ y.t < c.t} })
+                         ELSE NoTicket;
         end with;
       end with;
 
@@ -339,10 +401,10 @@ begin
       \*     holder's claim still held -> defer; gone -> ack.  R-A's rule unchanged,
       \*     made atomic, so a deferral is never written behind a released claim.
       if (IF SafeAcks
-            THEN \E own \in claims[ap_dst] : own.w = ap_dst /\ own.t < ap_ct
+            THEN \E own \in claims[ap_dst] : own.n = ap_dst /\ own.t < ap_ct
             ELSE ap_defer)
       then
-        deferred := deferred \cup { <<ap_dst, ap_ct>> };
+        deferred := deferred \cup { <<ap_dst, ap_ct, ap_behind>> };
       else
         acks := acks \cup { <<ap_ct, ap_dst>> };
       end if;
@@ -366,7 +428,7 @@ begin
 end process;
 
 end algorithm; *)
-\* BEGIN TRANSLATION (chksum(pcal) = "14190c1" /\ chksum(tla) = "a5729adc")
+\* BEGIN TRANSLATION (chksum(pcal) = "31d6d69e" /\ chksum(tla) = "3f1a640d")
 VARIABLES pc, next_ticket, claims, acks, deferred, iceberg, decision, crashed, 
           crash_budget
 
@@ -377,18 +439,29 @@ IcebergHead    == Len(iceberg)
 
 
 
+NodeLive(nd)   == \E w \in nd : ~ crashed[w]
 
 
 
 
 
-AlivePeersHaveAcked(self, t) ==
-  \A p \in Writers :
-    p = self \/ ~ Live(p) \/ <<t, p>> \in acks
 
 
-MyDeferredTickets(self) ==
-  { t : <<p, t>> \in {x \in deferred : x[1] = self} }
+
+AllPeerNodesAcked(self, t) ==
+  \A nd \in Nodes :
+    nd = Nd(self) \/ ~ NodeLive(nd) \/ <<t, nd>> \in acks
+
+
+
+
+SmallestOnMyNode(self, t) ==
+  ~ \E x \in claims[Nd(self)] : x.n = Nd(self) /\ x.w # self /\ x.t < t
+
+
+
+MyForwardable(self, t) ==
+  { d \in deferred : d[1] = Nd(self) /\ d[3] = t }
 
 
 NoLakekeeperConflict ==
@@ -400,7 +473,7 @@ RollbackNoIceberg ==
       ~ \E i \in 1..Len(iceberg) : iceberg[i].w = w
 
 UniqueTickets ==
-  \A p, q \in Writers :
+  \A p, q \in Nodes :
     \A x \in claims[p], y \in claims[q] :
       x.t = y.t => x.w = y.w
 
@@ -421,17 +494,18 @@ TicketOrderPreserved ==
 EventualProgress ==
   \A w \in Writers : <>(decision[w] \in {"committed", "rolled_back", "lk_409"})
 
-VARIABLES my_ticket, parent_seen, parent_staged, ap_dst, ap_ct, ap_defer
+VARIABLES my_ticket, parent_seen, parent_staged, ap_dst, ap_ct, ap_defer, 
+          ap_behind
 
 vars == << pc, next_ticket, claims, acks, deferred, iceberg, decision, 
            crashed, crash_budget, my_ticket, parent_seen, parent_staged, 
-           ap_dst, ap_ct, ap_defer >>
+           ap_dst, ap_ct, ap_defer, ap_behind >>
 
 ProcSet == (Writers) \cup {"applier"} \cup {"crasher"}
 
 Init == (* Global variables *)
         /\ next_ticket = 1
-        /\ claims = [w \in Writers |-> {}]
+        /\ claims = [nd \in Nodes |-> {}]
         /\ acks = {}
         /\ deferred = {}
         /\ iceberg = << [w |-> 0, t |-> 0, parent |-> 0, kind |-> "prime"] >>
@@ -446,6 +520,7 @@ Init == (* Global variables *)
         /\ ap_dst = NoTicket
         /\ ap_ct = NoTicket
         /\ ap_defer = FALSE
+        /\ ap_behind = NoTicket
         /\ pc = [self \in ProcSet |-> CASE self \in Writers -> "Start"
                                         [] self = "applier" -> "ApplyLoop"
                                         [] self = "crasher" -> "CrashLoop"]
@@ -456,7 +531,7 @@ Start(self) == /\ pc[self] = "Start"
                /\ UNCHANGED << next_ticket, claims, acks, deferred, iceberg, 
                                decision, crashed, crash_budget, my_ticket, 
                                parent_seen, parent_staged, ap_dst, ap_ct, 
-                               ap_defer >>
+                               ap_defer, ap_behind >>
 
 Stage(self) == /\ pc[self] = "Stage"
                /\ Live(self)
@@ -467,27 +542,31 @@ Stage(self) == /\ pc[self] = "Stage"
                /\ pc' = [pc EXCEPT ![self] = "BeginClaim"]
                /\ UNCHANGED << next_ticket, claims, acks, deferred, iceberg, 
                                decision, crashed, crash_budget, my_ticket, 
-                               parent_seen, ap_dst, ap_ct, ap_defer >>
+                               parent_seen, ap_dst, ap_ct, ap_defer, ap_behind >>
 
 BeginClaim(self) == /\ pc[self] = "BeginClaim"
                     /\ Live(self) /\ \E p \in Writers : p # self /\ Live(p)
                     /\ next_ticket <= MaxTickets
+                    /\ (~ SameNodeLock)
+                       \/ ~ \E x \in claims[Nd(self)] : x.n = Nd(self) /\ x.w # self
                     /\ my_ticket' = [my_ticket EXCEPT ![self] = next_ticket]
                     /\ next_ticket' = next_ticket + 1
-                    /\ claims' = [claims EXCEPT ![self] = claims[self] \cup
-                                                          {[w |-> self, t |-> my_ticket'[self], n |-> self]}]
+                    /\ claims' = [claims EXCEPT ![Nd(self)] = claims[Nd(self)] \cup
+                                                              {[w |-> self, t |-> my_ticket'[self], n |-> Nd(self)]}]
                     /\ pc' = [pc EXCEPT ![self] = "WaitAcks"]
                     /\ UNCHANGED << acks, deferred, iceberg, decision, crashed, 
                                     crash_budget, parent_seen, parent_staged, 
-                                    ap_dst, ap_ct, ap_defer >>
+                                    ap_dst, ap_ct, ap_defer, ap_behind >>
 
 WaitAcks(self) == /\ pc[self] = "WaitAcks"
-                  /\ Live(self) /\ AlivePeersHaveAcked(self, my_ticket[self])
+                  /\ Live(self)
+                     /\ SmallestOnMyNode(self, my_ticket[self])
+                     /\ AllPeerNodesAcked(self, my_ticket[self])
                   /\ pc' = [pc EXCEPT ![self] = "Prepare"]
                   /\ UNCHANGED << next_ticket, claims, acks, deferred, iceberg, 
                                   decision, crashed, crash_budget, my_ticket, 
                                   parent_seen, parent_staged, ap_dst, ap_ct, 
-                                  ap_defer >>
+                                  ap_defer, ap_behind >>
 
 Prepare(self) == /\ pc[self] = "Prepare"
                  /\ Live(self)
@@ -497,7 +576,8 @@ Prepare(self) == /\ pc[self] = "Prepare"
                  /\ pc' = [pc EXCEPT ![self] = "Decide"]
                  /\ UNCHANGED << next_ticket, claims, acks, deferred, iceberg, 
                                  decision, crashed, crash_budget, my_ticket, 
-                                 parent_staged, ap_dst, ap_ct, ap_defer >>
+                                 parent_staged, ap_dst, ap_ct, ap_defer, 
+                                 ap_behind >>
 
 Decide(self) == /\ pc[self] = "Decide"
                 /\ Live(self)
@@ -513,35 +593,36 @@ Decide(self) == /\ pc[self] = "Decide"
                 /\ pc' = [pc EXCEPT ![self] = "Release"]
                 /\ UNCHANGED << next_ticket, claims, acks, deferred, crashed, 
                                 crash_budget, my_ticket, parent_seen, 
-                                parent_staged, ap_dst, ap_ct, ap_defer >>
+                                parent_staged, ap_dst, ap_ct, ap_defer, 
+                                ap_behind >>
 
 Release(self) == /\ pc[self] = "Release"
                  /\ Live(self)
-                 /\ claims' = [p \in Writers |->
-                                claims[p] \ {[w |-> self, t |-> my_ticket[self], n |-> self]}]
+                 /\ claims' = [nd \in Nodes |->
+                                claims[nd] \ {[w |-> self, t |-> my_ticket[self], n |-> Nd(self)]}]
                  /\ pc' = [pc EXCEPT ![self] = "DrainForward"]
                  /\ UNCHANGED << next_ticket, acks, deferred, iceberg, 
                                  decision, crashed, crash_budget, my_ticket, 
                                  parent_seen, parent_staged, ap_dst, ap_ct, 
-                                 ap_defer >>
+                                 ap_defer, ap_behind >>
 
 DrainForward(self) == /\ pc[self] = "DrainForward"
                       /\ Live(self)
-                      /\ acks' = (acks \cup { <<t, self>> : t \in MyDeferredTickets(self) })
+                      /\ acks' = (acks \cup { <<d[2], Nd(self)>> : d \in MyForwardable(self, my_ticket[self]) })
                       /\ pc' = [pc EXCEPT ![self] = "DrainDelete"]
                       /\ UNCHANGED << next_ticket, claims, deferred, iceberg, 
                                       decision, crashed, crash_budget, 
                                       my_ticket, parent_seen, parent_staged, 
-                                      ap_dst, ap_ct, ap_defer >>
+                                      ap_dst, ap_ct, ap_defer, ap_behind >>
 
 DrainDelete(self) == /\ pc[self] = "DrainDelete"
                      /\ Live(self)
-                     /\ deferred' = { x \in deferred : x[1] # self }
+                     /\ deferred' = { x \in deferred : ~ (x[1] = Nd(self) /\ x[3] = my_ticket[self]) }
                      /\ pc' = [pc EXCEPT ![self] = "Done"]
                      /\ UNCHANGED << next_ticket, claims, acks, iceberg, 
                                      decision, crashed, crash_budget, 
                                      my_ticket, parent_seen, parent_staged, 
-                                     ap_dst, ap_ct, ap_defer >>
+                                     ap_dst, ap_ct, ap_defer, ap_behind >>
 
 Writer(self) == Start(self) \/ Stage(self) \/ BeginClaim(self)
                    \/ WaitAcks(self) \/ Prepare(self) \/ Decide(self)
@@ -549,14 +630,18 @@ Writer(self) == Start(self) \/ Stage(self) \/ BeginClaim(self)
                    \/ DrainDelete(self)
 
 ApplyLoop == /\ pc["applier"] = "ApplyLoop"
-             /\ \E src \in Writers:
-                  \E dst \in Writers:
-                    /\ dst # src /\ Live(dst)
-                    /\ \E c \in { x \in claims[src] : x \notin claims[dst] /\ x.w = src }:
+             /\ \E src \in Nodes:
+                  \E dst \in Nodes:
+                    /\ dst # src /\ NodeLive(dst)
+                    /\ \E c \in { x \in claims[src] : x \notin claims[dst] /\ x.n = src }:
                          /\ claims' = [claims EXCEPT ![dst] = claims[dst] \cup { c }]
                          /\ ap_dst' = dst
                          /\ ap_ct' = c.t
-                         /\ ap_defer' = (\E own \in claims'[dst] : own.w = dst /\ own.t < c.t)
+                         /\ ap_defer' = (\E own \in claims'[dst] : own.n = dst /\ own.t < c.t)
+                         /\ ap_behind' = (IF \E own \in claims'[dst] : own.n = dst /\ own.t < c.t
+                                            THEN MinT({ own.t : own \in
+                                                  {y \in claims'[dst] : y.n = dst /\ y.t < c.t} })
+                                            ELSE NoTicket)
              /\ pc' = [pc EXCEPT !["applier"] = "ApplyEmit"]
              /\ UNCHANGED << next_ticket, acks, deferred, iceberg, decision, 
                              crashed, crash_budget, my_ticket, parent_seen, 
@@ -564,16 +649,16 @@ ApplyLoop == /\ pc["applier"] = "ApplyLoop"
 
 ApplyEmit == /\ pc["applier"] = "ApplyEmit"
              /\ IF (IF SafeAcks
-                      THEN \E own \in claims[ap_dst] : own.w = ap_dst /\ own.t < ap_ct
+                      THEN \E own \in claims[ap_dst] : own.n = ap_dst /\ own.t < ap_ct
                       ELSE ap_defer)
-                   THEN /\ deferred' = (deferred \cup { <<ap_dst, ap_ct>> })
+                   THEN /\ deferred' = (deferred \cup { <<ap_dst, ap_ct, ap_behind>> })
                         /\ acks' = acks
                    ELSE /\ acks' = (acks \cup { <<ap_ct, ap_dst>> })
                         /\ UNCHANGED deferred
              /\ pc' = [pc EXCEPT !["applier"] = "ApplyLoop"]
              /\ UNCHANGED << next_ticket, claims, iceberg, decision, crashed, 
                              crash_budget, my_ticket, parent_seen, 
-                             parent_staged, ap_dst, ap_ct, ap_defer >>
+                             parent_staged, ap_dst, ap_ct, ap_defer, ap_behind >>
 
 Applier == ApplyLoop \/ ApplyEmit
 
@@ -590,7 +675,7 @@ CrashLoop == /\ pc["crasher"] = "CrashLoop"
                         /\ UNCHANGED << crashed, crash_budget >>
              /\ UNCHANGED << next_ticket, claims, acks, deferred, iceberg, 
                              decision, my_ticket, parent_seen, parent_staged, 
-                             ap_dst, ap_ct, ap_defer >>
+                             ap_dst, ap_ct, ap_defer, ap_behind >>
 
 Crasher == CrashLoop
 

--- a/docs/formal/Bakery_v2_async.cfg
+++ b/docs/formal/Bakery_v2_async.cfg
@@ -9,6 +9,8 @@
 
 CONSTANTS
   Writers       = {w1, w2, w3}
+  NodeParts     = {{w1}, {w2}, {w3}}
+  SameNodeLock  = TRUE
   MaxTickets    = 6
   MaxIcebergLen = 5
   MaxCrashes    = 0

--- a/docs/formal/Bakery_v2_crash.cfg
+++ b/docs/formal/Bakery_v2_crash.cfg
@@ -3,6 +3,8 @@
 \* checks the stock ordering and the result carries to the async ordering.
 CONSTANTS
   Writers       = {w1, w2, w3}
+  NodeParts     = {{w1}, {w2}, {w3}}
+  SameNodeLock  = TRUE
   MaxTickets    = 6
   MaxIcebergLen = 5
   MaxCrashes    = 1

--- a/docs/formal/Bakery_v2_fixed.cfg
+++ b/docs/formal/Bakery_v2_fixed.cfg
@@ -8,6 +8,8 @@
 \* No SYMMETRY (unsound with liveness checking in TLC).
 CONSTANTS
   Writers       = {w1, w2, w3}
+  NodeParts     = {{w1}, {w2}, {w3}}
+  SameNodeLock  = TRUE
   MaxTickets    = 6
   MaxIcebergLen = 5
   MaxCrashes    = 0

--- a/docs/formal/Bakery_v2_live.cfg
+++ b/docs/formal/Bakery_v2_live.cfg
@@ -8,6 +8,8 @@
 \* No SYMMETRY (unsound with liveness checking in TLC).
 CONSTANTS
   Writers       = {w1, w2, w3}
+  NodeParts     = {{w1}, {w2}, {w3}}
+  SameNodeLock  = TRUE
   MaxTickets    = 6
   MaxIcebergLen = 5
   MaxCrashes    = 0

--- a/docs/formal/Bakery_v2_race.cfg
+++ b/docs/formal/Bakery_v2_race.cfg
@@ -14,6 +14,8 @@
 
 CONSTANTS
   Writers       = {w1, w2, w3}
+  NodeParts     = {{w1}, {w2}, {w3}}
+  SameNodeLock  = TRUE
   MaxTickets    = 6
   MaxIcebergLen = 5
   MaxCrashes    = 0

--- a/docs/formal/Bakery_v2_samenode.cfg
+++ b/docs/formal/Bakery_v2_samenode.cfg
@@ -1,0 +1,30 @@
+\* TLC config for Bakery_v2.tla — MULTIPLE cold writers per node, WITH the
+\* node-local advisory lock (EXPECTED to PASS). Same topology as
+\* Bakery_v2_samenode_race.cfg (a1, a2 on node nA; b1 on node nB) but
+\* SameNodeLock = TRUE models coldfront._claim_iceberg_lock: at most one
+\* same-node writer is in the bakery at a time. a1 and a2 never coexist, so the
+\* ack-forward never clears b1 while a2 still holds — the topology collapses to
+\* one active claim per node, which the R-A bakery already serializes safely.
+\*
+\* TLC is EXPECTED to report all four invariants hold (no error). Together with
+\* Bakery_v2_samenode_race.cfg this is the formal proof that the same-node
+\* advisory lock is MANDATORY for multi-writer-per-node cold writes. No crashes.
+
+CONSTANTS
+  Writers       = {a1, a2, b1}
+  NodeParts     = {{a1, a2}, {b1}}
+  SameNodeLock  = TRUE
+  MaxTickets    = 3
+  MaxIcebergLen = 5
+  MaxCrashes    = 0
+  AsyncParquet  = FALSE
+  RestampPatch  = FALSE
+  SafeAcks      = TRUE
+
+SPECIFICATION Spec
+
+INVARIANTS
+  NoLakekeeperConflict
+  RollbackNoIceberg
+  UniqueTickets
+  TicketOrderPreserved

--- a/docs/formal/Bakery_v2_samenode_race.cfg
+++ b/docs/formal/Bakery_v2_samenode_race.cfg
@@ -1,0 +1,32 @@
+\* TLC config for Bakery_v2.tla — MULTIPLE cold writers per node, NO same-node
+\* lock (EXPECTED to FAIL). Two writers a1 < a2 share node nA; b1 is on node nB,
+\* with a1 < a2 < b1. Node nA defers b1 behind its SMALLEST same-node claim (a1);
+\* when a1 releases, nA forwards its ack for b1 WITHOUT re-deferring behind a2
+\* (still held, still < b1). So a2 (already acked by nB) and b1 (now acked by nA)
+\* both clear the bakery and race the CAS → one gets a Lakekeeper 409.
+\*
+\* TLC is EXPECTED to report `NoLakekeeperConflict` violated, with a counter-
+\* example trace. Bakery_v2_samenode.cfg (SameNodeLock = TRUE) proves the
+\* node-local advisory lock restores safety. SafeAcks = TRUE isolates this
+\* same-node race from the ack-atomicity race (Bakery_v2_live.cfg); the stock
+\* ordering (AsyncParquet = FALSE) isolates it from the async CAS race
+\* (Bakery_v2_race.cfg). No crashes.
+
+CONSTANTS
+  Writers       = {a1, a2, b1}
+  NodeParts     = {{a1, a2}, {b1}}
+  SameNodeLock  = FALSE
+  MaxTickets    = 3
+  MaxIcebergLen = 5
+  MaxCrashes    = 0
+  AsyncParquet  = FALSE
+  RestampPatch  = FALSE
+  SafeAcks      = TRUE
+
+SPECIFICATION Spec
+
+INVARIANTS
+  NoLakekeeperConflict
+  RollbackNoIceberg
+  UniqueTickets
+  TicketOrderPreserved

--- a/docs/formal/README.md
+++ b/docs/formal/README.md
@@ -46,6 +46,8 @@ describes its files and their roles:
 | `Bakery_v2_crash.cfg` | 3 writers, 1 crash budget (stock ordering - crash-safety is ordering-independent).  Safety invariants still hold (a crashed peer's missing ack just leaves surviving writers blocked at `WaitAcks` - no incorrect commits). |
 | `Bakery_v2_live.cfg` | **The defer/drain race** (`SafeAcks=FALSE`) - the non-atomic implementation. **`EventualProgress` is EXPECTED to be VIOLATED**: a deferred ack written behind a just-released claim is dropped, stranding the min-ticket holder at `WaitAcks` forever - the N-writer production wedge, reproduced in the model. The four safety invariants still HOLD (a dropped ack is a liveness failure, not a wrong commit). No `SYMMETRY` (unsound with liveness checking). |
 | `Bakery_v2_fixed.cfg` | **The fix** (`SafeAcks=TRUE`) - the atomic defer/drain (`FOR UPDATE` on the claim row). `EventualProgress` HOLDS *and* all four safety invariants hold: the formal proof the fix restores liveness without weakening safety. |
+| `Bakery_v2_samenode_race.cfg` | **Multiple cold writers per node, no same-node lock** (`NodeParts={{a1,a2},{b1}}`, `SameNodeLock=FALSE`). Two same-node claims `a1<a2` below a peer's `b1`: the node defers `b1` behind its smallest same-node claim `a1` and, on `a1`'s release, forwards the ack for `b1` without re-deferring behind `a2` (still held, still `< b1`), so `a2` and `b1` both clear the bakery. **`NoLakekeeperConflict` is EXPECTED to be violated** - the multi-writer-per-node race, reproduced in the model. |
+| `Bakery_v2_samenode.cfg` | **The fix** (`SameNodeLock=TRUE`) - `coldfront._claim_iceberg_lock`'s node-local advisory xact lock, so at most one same-node writer is in the bakery at a time. `a1` and `a2` never coexist; the topology collapses to one active claim per node and all four safety invariants HOLD: the formal proof the node-local lock is mandatory for multi-writer-per-node cold writes. |
 
 ## Properties
 
@@ -155,6 +157,14 @@ java -cp $TLA tlc2.TLC -workers auto -deadlock -config Bakery_v2_live.cfg Bakery
 # v2.f The fix (SafeAcks=TRUE — FOR UPDATE on the claim row).  All hold:
 #       EventualProgress AND the four safety invariants.
 java -cp $TLA tlc2.TLC -workers auto -deadlock -config Bakery_v2_fixed.cfg Bakery_v2.tla
+
+# v2.g Multiple cold writers per node, NO same-node lock (SameNodeLock=FALSE).
+#      EXPECTED to violate NoLakekeeperConflict — the multi-writer-per-node race.
+java -cp $TLA tlc2.TLC -workers auto -deadlock -config Bakery_v2_samenode_race.cfg Bakery_v2.tla
+
+# v2.h Same topology WITH the node-local advisory lock (SameNodeLock=TRUE).
+#      All four safety invariants HOLD — the lock restores safety.
+java -cp $TLA tlc2.TLC -workers auto -deadlock -config Bakery_v2_samenode.cfg Bakery_v2.tla
 ```
 
 The `-deadlock` flag tells TLC not to flag final stuttering states as
@@ -265,6 +275,44 @@ needs no patch. (The asymmetric-apply race that motivates R-A itself -
 two writers passing a naive local min-check on stale views - is
 structurally prevented by the R-A ack barrier in this model, so it has
 no standalone config.)
+
+### `Bakery_v2_samenode_race.cfg` (multi-writer-per-node - EXPECTED FAILURE)
+
+The no-same-node-lock config is expected to fail the check, reporting
+the following output:
+
+```text
+Error: Invariant NoLakekeeperConflict is violated.
+…
+62256 states generated, 20448 distinct states found, 2595 states left on queue.
+```
+
+**Failure expected.** With two cold writers `a1 < a2` on one node and
+`b1` on a peer (`NodeParts={{a1,a2},{b1}}`, `SameNodeLock=FALSE`), the
+node defers `b1` behind its smallest same-node claim `a1`; when `a1`
+releases, it forwards the ack for `b1` without re-deferring behind `a2`
+(still held, still `< b1`). So `a2` (already acked by the peer, since
+`a2 < b1`) and `b1` (now acked) both clear the bakery and race the CAS →
+Lakekeeper 409. This reproduces the multi-writer-per-node race in the
+model, isolated from the async race (`AsyncParquet=FALSE`) and the
+ack-atomicity race (`SafeAcks=TRUE`).
+
+### `Bakery_v2_samenode.cfg` (node-local lock)
+
+The same-node-lock config reports a clean check with the following
+output:
+
+```text
+Model checking completed. No error has been found.
+71617 states generated, 24076 distinct states found, 0 states left on queue.
+```
+
+`SameNodeLock=TRUE` models `coldfront._claim_iceberg_lock`'s node-local
+advisory xact lock: at most one same-node writer is in the bakery at a
+time. `a1` and `a2` never coexist, so the ack-forward never clears `b1`
+while `a2` still holds; the topology collapses to one active claim per
+node and all four safety invariants hold. This is the formal proof that
+the node-local lock is mandatory for multi-writer-per-node cold writes.
 
 ## Model fidelity
 

--- a/extension/coldfront/coldfront--1.0.sql
+++ b/extension/coldfront/coldfront--1.0.sql
@@ -208,7 +208,7 @@ BEGIN
     PERFORM duckdb.raw_query($q$SET GLOBAL httpfs_client_implementation = 'httplib'$q$);
     -- httpfs (s3) already loaded as a side-effect of the ATTACH above; azure does
     -- not, so its lazy autoload would otherwise fire later as the non-superuser
-    -- app role and hit pg_duckdb's LocalFileSystem block (issue #17). Pre-load it
+    -- app role and hit pg_duckdb's LocalFileSystem block. Pre-load it
     -- here, while still in this SECURITY DEFINER (elevated) context.
     IF EXISTS (SELECT 1 FROM coldfront.storage_secret WHERE storage_type = 'azure') THEN
       PERFORM duckdb.raw_query('LOAD azure');
@@ -2061,6 +2061,15 @@ BEGIN
     IF connstr IS NULL OR connstr = '' THEN
         RAISE EXCEPTION 'coldfront: configure GUC coldfront.dblink_self with a libpq connstr (e.g. ''host=/var/run/postgresql dbname=coldfront user=coldfront'')';
     END IF;
+
+    -- Same-node serialization: hold a node-local advisory xact lock for this
+    -- iceberg table across the whole claim+commit, so at most ONE cold writer
+    -- per node is in the bakery at once. That keeps per-node concurrency at 1
+    -- (the topology Bakery_v2 proves safe), so the cross-node Ricart-Agrawala
+    -- ack/defer only ever arbitrates a single same-node claim. Cross-node
+    -- writers are unaffected (advisory locks are instance-local); in the async
+    -- path this runs after the parquet upload, so same-node uploads pipeline.
+    PERFORM pg_advisory_xact_lock(hashtext('coldfront_iceberg:' || p_iceberg_table));
 
     -- Persistent named dblink connection (sessionful, opened once).
     -- The dblink session only touches coldfront.claims (never a tiered view),


### PR DESCRIPTION
On a Spock mesh the bakery serialized cold writers per node via the claim's same-node ordering, but with more than one writer per node on 2+ nodes the cross-node ack/defer could let two commits reach Lakekeeper at once (CatalogCommitConflicts 409). _claim_iceberg_lock now takes a node-local advisory xact lock before claiming, so at most one cold writer per node is in the bakery at a time, which is the one-claim-per-node topology Bakery_v2 already proves.

Adds a mesh reproducer (story_mesh_multiwriter, red before / green after) and a deployment-refinement note in the model. Verified: decoupled mesh journey 41/0, TLC safe config No error, race config still violates.

Fixes #35