### PR TITLE
refactor: make register the configuration path for managed tables

### DIFF
--- a/ci/journey.sh
+++ b/ci/journey.sh
@@ -178,7 +178,11 @@ archiver:
       partition_period: monthly
       hot_period: "${ret_days} days"
 EOF
-    if "$ARCHIVER" --config /tmp/journey-archiver.yaml >/tmp/journey-archiver.log 2>&1; then
+    # Managed tables live in coldfront.partition_config; seed events from the YAML.
+    if ! "$ARCHIVER" import --config /tmp/journey-archiver.yaml >/tmp/journey-archiver.log 2>&1; then
+        fail "import events into partition_config — see /tmp/journey-archiver.log"; tail -5 /tmp/journey-archiver.log; return
+    fi
+    if "$ARCHIVER" --config /tmp/journey-archiver.yaml >>/tmp/journey-archiver.log 2>&1; then
         pass "archiver first run completed"
     else
         fail "archiver first run — see /tmp/journey-archiver.log"; tail -5 /tmp/journey-archiver.log
@@ -225,7 +229,11 @@ archiver:
       hot_period: "${ret_days} days"
       retention_period: "${ret_long} days"
 EOF
-    if "$ARCHIVER" --config /tmp/journey-coldret.yaml >/tmp/journey-coldret.log 2>&1; then
+    # events is already managed (tiered); add the drop boundary via set.
+    if ! "$ARCHIVER" set --config /tmp/journey-coldret.yaml --table events --retention "${ret_long} days" >/tmp/journey-coldret.log 2>&1; then
+        fail "set retention on events — see /tmp/journey-coldret.log"; tail -5 /tmp/journey-coldret.log; return
+    fi
+    if "$ARCHIVER" --config /tmp/journey-coldret.yaml >>/tmp/journey-coldret.log 2>&1; then
         pass "archiver cold-retention run completed"
     else
         fail "archiver cold-retention run — see /tmp/journey-coldret.log"; tail -5 /tmp/journey-coldret.log
@@ -460,7 +468,10 @@ iceberg:  { warehouse: "${WAREHOUSE}", lakekeeper_endpoint: "http://${LK_IP}:818
 $(storage_yaml)
 archiver: { tables: [ { source_table: typed, partition_period: monthly, hot_period: "${ret_days} days" } ] }
 EOF
-    if "$ARCHIVER" --config /tmp/journey-typed.yaml >/tmp/journey-typed.log 2>&1; then
+    if ! "$ARCHIVER" import --config /tmp/journey-typed.yaml >/tmp/journey-typed.log 2>&1; then
+        fail "import typed into partition_config — see /tmp/journey-typed.log"; tail -5 /tmp/journey-typed.log; return
+    fi
+    if "$ARCHIVER" --config /tmp/journey-typed.yaml >>/tmp/journey-typed.log 2>&1; then
         pass "typed table archived (Jan → cold)"
     else
         fail "typed archive — see /tmp/journey-typed.log"; tail -5 /tmp/journey-typed.log
@@ -1002,7 +1013,13 @@ iceberg:  { warehouse: "${WAREHOUSE}", lakekeeper_endpoint: "http://${LK_IP}:818
 $(storage_yaml)
 archiver: { tables: [ { source_table: events, partition_period: monthly, hot_period: "${ret_race} days" } ] }
 EOF
-    "$ARCHIVER" --config /tmp/journey-race.yaml --debug-export-delay 4s >/tmp/journey-race.log 2>&1 &
+    # Widen events' hot window for this run so m1 expires now; restore it after
+    # the run (one shared partition_config row) so later stories keep events' config.
+    local prev_hot; prev_hot=$(q "$HOST" "SELECT hot_period::text FROM coldfront.partition_config WHERE schema_name='public' AND table_name='events';")
+    if ! "$ARCHIVER" set --config /tmp/journey-race.yaml --table events --hot-period "${ret_race} days" >/tmp/journey-race.log 2>&1; then
+        fail "set race hot-period on events — see /tmp/journey-race.log"; tail -5 /tmp/journey-race.log; return
+    fi
+    "$ARCHIVER" --config /tmp/journey-race.yaml --debug-export-delay 4s >>/tmp/journey-race.log 2>&1 &
     local apid=$!
     local i
     for i in $(seq 1 30); do
@@ -1018,6 +1035,10 @@ INSERT INTO events (ts, status, data) VALUES (date_trunc('month',now()) - interv
 EOSQL
     if wait "$apid"; then pass "archiver cycle 2 completed cleanly (no 409)"
     else fail "archiver errored during race window"; tail -5 /tmp/journey-race.log; fi
+    # Restore events' hot_period (shared partition_config row) so later stories see
+    # its original config; a failed restore would corrupt them, so fail loud.
+    "$ARCHIVER" set --config /tmp/journey-race.yaml --table events --hot-period "$prev_hot" >/dev/null 2>&1 \
+        || fail "restore events hot_period after race window"
     assert_eq "race UPDATEs survived (3 retagged in cold)" "3" "$(q "$HOST" "SELECT count(*) FROM events WHERE status='during_archive';")"
     assert_eq "race INSERT survived (1 new in cold)"       "1" "$(q "$HOST" "SELECT count(*) FROM events WHERE status='during_archive_insert';")"
     assert_eq "race DELETE survived (0 remaining)"         "0" "$(q "$HOST" "SELECT count(*) FROM events WHERE status='race_will_delete';")"
@@ -1492,7 +1513,10 @@ archiver:
       hot_period: "${ret_days} days"
       sub_partition: { values_source: "SELECT region FROM (VALUES ('eu'),('us')) r(region)" }
 EOF
-    if "$ARCHIVER" --config /tmp/journey-tl.yaml >/tmp/journey-tl.log 2>&1; then
+    if ! "$ARCHIVER" import --config /tmp/journey-tl.yaml >/tmp/journey-tl.log 2>&1; then
+        fail "import regional (2-level) into partition_config — see /tmp/journey-tl.log"; tail -8 /tmp/journey-tl.log; return
+    fi
+    if "$ARCHIVER" --config /tmp/journey-tl.yaml >>/tmp/journey-tl.log 2>&1; then
         pass "2-level archiver run completed (no flat-partitioning Fatal)"
     else
         fail "2-level archiver run — see /tmp/journey-tl.log"; tail -8 /tmp/journey-tl.log; return
@@ -1580,6 +1604,22 @@ EOSQL
         if grep -qi "primary key" /tmp/journey-nopk.log; then pass "register rejects the PK-less table"; else fail "wrong rejection reason"; tail -3 /tmp/journey-nopk.log; fi
     fi
     assert_eq "no row written for the rejected table" "0" \
+        "$(q "$HOST" "SELECT count(*) FROM coldfront.partition_config WHERE table_name='cli_nopk';")"
+
+    # Parity: import must reject the SAME PK-less table register rejects — every
+    # write to partition_config goes through one validation gate.
+    # Partition-only (retention, no hot_period) so the config needs no cold backend;
+    # the PK-superset check still fires and must reject the PK-less table.
+    cat > /tmp/journey-nopk.yaml <<EOF
+postgres: { dsn: "host=${DB_IP} port=5432 dbname=coldfront user=coldfront password=coldfront sslmode=disable" }
+archiver: { tables: [ { source_table: cli_nopk, partition_period: monthly, retention_period: "60 months" } ] }
+EOF
+    if "$ARCHIVER" import --config /tmp/journey-nopk.yaml >/tmp/journey-nopk-imp.log 2>&1; then
+        fail "import cli_nopk should have failed (no primary key)"
+    else
+        if grep -qi "primary key" /tmp/journey-nopk-imp.log; then pass "import rejects the PK-less table (parity with register)"; else fail "wrong import rejection reason"; tail -3 /tmp/journey-nopk-imp.log; fi
+    fi
+    assert_eq "import wrote no row for the rejected table" "0" \
         "$(q "$HOST" "SELECT count(*) FROM coldfront.partition_config WHERE table_name='cli_nopk';")"
 
     # retention must exceed hot-period — caught at register time, before any write.
@@ -1724,10 +1764,9 @@ story_partitioner_multitable() {
 # a unified view left in events' place) the standalone partitioner must premake
 # against the real partitioned table (_events), not the view. The configured /
 # registered source name is still "events"; reconcileTable resolves it to the
-# "_"+name partitioned relation before building the spec. Pre-fix the partitioner
-# targeted the view and aborted on the verify-attach guard ("not
-# attached … different parent"); post-fix it premakes the forward window straight
-# onto _events.
+# "_"+name partitioned relation before building the spec, so it premakes the
+# forward window straight onto _events and never touches the view (which would
+# trip the verify-attach guard: "not attached … different parent").
 # ───────────────────────────────────────────────────────────────────────────
 story_partitioner_after_swap() {
     step "Partitioner after first-run swap: premakes onto _events, not the view"
@@ -1736,21 +1775,22 @@ story_partitioner_after_swap() {
     assert_eq "precondition — events is a view"       "v" "$(q "$HOST" "SELECT relkind FROM pg_class WHERE relname='events'  AND relnamespace='public'::regnamespace;")"
     assert_eq "precondition — _events is partitioned" "p" "$(q "$HOST" "SELECT relkind FROM pg_class WHERE relname='_events' AND relnamespace='public'::regnamespace;")"
     local dsn="host=${DB_IP} port=5432 dbname=coldfront user=coldfront password=coldfront sslmode=disable"
-    # Drive the partitioner off the post-swap source name "events" with a wide
-    # future window (6) so it premakes months the archiver (premake 3) did not —
-    # proving it acted on _events. retention 60 months drops nothing.
-    cat > /tmp/journey-partitioner.yaml <<EOF
-postgres:
-  dsn: "${dsn}"
-archiver:
-  tables:
-    - source_table: events
-      partition_period: monthly
-      retention_period: "60 months"
-      future_partitions: 6
-EOF
-    if ! "$PARTITIONER" --config /tmp/journey-partitioner.yaml >/tmp/journey-partitioner.log 2>&1; then
-        fail "partitioner run failed"; tail -8 /tmp/journey-partitioner.log; return
+    printf 'postgres: { dsn: "%s" }\n' "$dsn" > /tmp/journey-partitioner.yaml
+    # events is archiver-owned (tiered). Temporarily make it partition-only so the
+    # standalone partitioner manages it and premakes a wide future window (6, vs the
+    # archiver's 3) — proving it resolves the events VIEW to the real _events table
+    # — then restore the tiered config for later stories. retention 60mo drops nothing.
+    local prev_hot prev_ret prev_pre
+    prev_hot=$(q "$HOST" "SELECT hot_period::text       FROM coldfront.partition_config WHERE schema_name='public' AND table_name='events';")
+    prev_ret=$(q "$HOST" "SELECT retention_period::text FROM coldfront.partition_config WHERE schema_name='public' AND table_name='events';")
+    prev_pre=$(q "$HOST" "SELECT future_partitions      FROM coldfront.partition_config WHERE schema_name='public' AND table_name='events';")
+    if ! "$PARTITIONER" set --config /tmp/journey-partitioner.yaml --table events --hot-period "" --retention "60 months" --premake 6 >/tmp/journey-partitioner.log 2>&1; then
+        fail "set events partition-only — see /tmp/journey-partitioner.log"; tail -5 /tmp/journey-partitioner.log; return
+    fi
+    if "$PARTITIONER" --config /tmp/journey-partitioner.yaml >>/tmp/journey-partitioner.log 2>&1; then
+        pass "partitioner ran off partition_config (events temporarily partition-only)"
+    else
+        fail "partitioner run failed"; tail -8 /tmp/journey-partitioner.log
     fi
     # The partitioner resolves events → _events, so the reconcile is logged against _events.
     if grep -q "\[_events\] reconciled" /tmp/journey-partitioner.log; then
@@ -1769,6 +1809,10 @@ EOF
     local fut; fut="events_p_$(date -u -d "$(date -u +%Y-%m-01) +5 months" +%Y_%m)"
     assert_eq "+5mo leaf $fut premade onto _events" "1" \
         "$(q "$HOST" "SELECT count(*) FROM pg_inherits i JOIN pg_class c ON c.oid=i.inhrelid WHERE i.inhparent='public._events'::regclass AND c.relname='$fut';")"
+    # Restore events' tiered config so later stories see it as the archiver owns it;
+    # a failed restore would corrupt them, so fail loud.
+    "$ARCHIVER" set --config /tmp/journey-partitioner.yaml --table events --hot-period "$prev_hot" --retention "$prev_ret" --premake "$prev_pre" >/dev/null 2>&1 \
+        || fail "restore events tiered config after partitioner-after-swap test"
 }
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/cmd/archiver/main.go
+++ b/cmd/archiver/main.go
@@ -116,24 +116,18 @@ func setupConnection(ctx context.Context, cfg *config.Config) (*pgx.Conn, *water
 	return conn, wmStore
 }
 
-// resolveAndValidateTables resolves managed tables from the replicated
-// coldfront.partition_config table (falling back to YAML archiver.tables),
-// assigns them onto cfg, and validates the config. Any failure log.Fatalf's.
+// resolveAndValidateTables loads the managed tables from the replicated
+// coldfront.partition_config table, assigns them onto cfg, and validates the
+// config. Any failure log.Fatalf's.
 func resolveAndValidateTables(ctx context.Context, cfg *config.Config, conn *pgx.Conn, configPath string) {
-	// Resolve managed tables from the replicated coldfront.partition_config
-	// table, falling back to the YAML archiver.tables (deprecation bridge).
-	tables, fromYAML, err := partcfg.ResolveTables(ctx, conn, cfg.Archiver.Tables, partcfg.Tiered)
+	tables, err := partcfg.ResolveTables(ctx, conn, partcfg.Tiered)
 	if err != nil {
 		log.Fatalf("resolve tables: %v", err)
 	}
 	if len(tables) == 0 {
-		log.Fatalf("no tables configured: coldfront.partition_config is empty and no archiver.tables in %s", configPath)
+		log.Fatalf("no tables in coldfront.partition_config; add one with `archiver register` or seed a YAML with `archiver import --config %s`", configPath)
 	}
-	if fromYAML {
-		log.Printf("no partition_config rows; using %d table(s) from YAML (deprecated — migrate with `register`/`import`)", len(tables))
-	} else {
-		log.Printf("loaded %d table(s) from coldfront.partition_config", len(tables))
-	}
+	log.Printf("loaded %d table(s) from coldfront.partition_config", len(tables))
 	cfg.Archiver.Tables = tables
 	if err := cfg.Validate(); err != nil {
 		log.Fatalf("config invalid: %v", err)

--- a/cmd/partitioner/main.go
+++ b/cmd/partitioner/main.go
@@ -102,24 +102,18 @@ func dispatchSubcommand(ctx context.Context) bool {
 	return false
 }
 
-// loadAndResolve resolves the managed tables from the replicated
-// coldfront.partition_config table (falling back to the YAML archiver.tables
-// deprecation bridge), writes them back onto cfg, and validates the config.
+// loadAndResolve loads the managed tables from the replicated
+// coldfront.partition_config table, writes them back onto cfg, and validates
+// the config.
 func loadAndResolve(ctx context.Context, conn *pgx.Conn, cfg *config.Config, cfgPath string) {
-	// Resolve managed tables from the replicated coldfront.partition_config
-	// table, falling back to the YAML archiver.tables (deprecation bridge).
-	tables, fromYAML, err := partcfg.ResolveTables(ctx, conn, cfg.Archiver.Tables, partcfg.PartitionOnly)
+	tables, err := partcfg.ResolveTables(ctx, conn, partcfg.PartitionOnly)
 	if err != nil {
 		log.Fatalf("resolve tables: %v", err)
 	}
 	if len(tables) == 0 {
-		log.Fatalf("no tables configured: coldfront.partition_config is empty and no archiver.tables in %s", cfgPath)
+		log.Fatalf("no tables in coldfront.partition_config; add one with `partitioner register` or seed a YAML with `partitioner import --config %s`", cfgPath)
 	}
-	if fromYAML {
-		log.Printf("no partition_config rows; using %d table(s) from YAML (deprecated — migrate with `register`/`import`)", len(tables))
-	} else {
-		log.Printf("loaded %d table(s) from coldfront.partition_config", len(tables))
-	}
+	log.Printf("loaded %d table(s) from coldfront.partition_config", len(tables))
 	cfg.Archiver.Tables = tables
 	if err := cfg.Validate(); err != nil {
 		log.Fatalf("config invalid: %v", err)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -54,6 +54,12 @@ s3:
 #   connection_string: "DefaultEndpointsProtocol=https;AccountName=<account>;AccountKey=<key>;EndpointSuffix=core.windows.net"
 
 archiver:
+  # Tiered tables live in coldfront.partition_config (replicated across a mesh);
+  # the archiver and partitioner read ONLY that table. Populate it with
+  # ./bin/archiver register (one table) or ./bin/archiver import --config <this
+  # file> (every table below, each validated exactly as register validates one).
+  # This tables: list is the import input and the export output format; it is not
+  # read at archive/partition time.
   tables:
     - source_table: "events"        # or "myschema.events"
       partition_period: "monthly"   # "monthly" or "daily"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -332,6 +332,14 @@ that replicates by value across a Spock mesh (like
 `partitioner` and `archiver` expose these subcommands; with no subcommand
 they do their normal reconcile/archive run).
 
+`register` is the primary way to manage tables: one command adds or adopts
+one table, validated on the spot. `import` and `export` are bulk helpers
+for (re)configuring a machine - seed a fresh node from a YAML, or dump the
+live config to git and replay it on another node - not the day-to-day
+path. Every write (`register`, `import`, `set`) goes through the same
+validation, so no command can leave `partition_config` in a state another
+command would reject.
+
 The data lifecycle is **hot PG → `hot_period` → cold Iceberg →
 `retention_period` → dropped** (tiered) or **hot PG → `retention_period`
 → dropped** (partition-only). Setting `hot_period` makes a table tiered;
@@ -352,8 +360,8 @@ The CLI exposes the following subcommands:
 | `list` | show managed tables and their lifecycle |
 | `set` | change fields, or `--disable`/`--enable` a table |
 | `remove` | stop managing a table (the table itself is left intact) |
-| `import` | seed `partition_config` from a YAML's `archiver.tables` (migration) |
-| `export` | dump the **active (enabled)** config to YAML or SQL - a git-reviewable copy |
+| `import` | bulk-load a machine's tables from a YAML's `archiver.tables` (provision/restore; each table validated as `register` does) |
+| `export` | dump the **active (enabled)** config to YAML or SQL - a git-reviewable backup to replay on another node |
 
 ```bash
 # Partition-only: keep 3 future partitions, drop those older than 12 months.
@@ -379,7 +387,7 @@ partitioner list   --config cf.yaml                      # what's managed
 partitioner set    --config cf.yaml --table events --retention "24 months"
 partitioner set    --config cf.yaml --table events --disable   # pause (keeps the row)
 partitioner remove --config cf.yaml --table events       # unregister, keep the table
-partitioner import --config legacy.yaml                  # migrate a YAML's tables
+partitioner import --config tables.yaml                  # register every table in a YAML at once
 partitioner export --config cf.yaml > managed.yaml       # active config, git-reviewable (--format sql for INSERTs)
 ```
 
@@ -394,9 +402,13 @@ required; `partition_column` is auto-detected from `pg_catalog` for flat
 tables (required for 2-level). `register` writes a row whose `CHECK`
 constraints enforce the lifecycle rules at write time.
 
-**YAML `archiver.tables` still works** as a deprecation bridge: when
-`partition_config` is empty the binaries fall back to a YAML table list.
-Move off it with `import`.
+**Managing tables:** the archiver and partitioner read the managed set
+only from `coldfront.partition_config`. `register` adds one table;
+`import` adds every table in a YAML `archiver.tables` list. Both write
+through the same validation (the PK must cover the partition key;
+`retention` must exceed `hot_period`), so an imported table is checked
+exactly as a registered one. `export` dumps the active rows back to YAML
+or SQL for git.
 
 ## Storage backends
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -202,9 +202,10 @@ func (c *Config) coldTierMode() (icebergMode, anyS3 bool) {
 }
 
 // validateTables checks every table entry, returning the first violation.
-// Zero tables is allowed here: the managed-table set may instead come from the
-// replicated coldfront.partition_config table, resolved at startup. The
-// binaries fail loud if BOTH the table and archiver.tables are empty.
+// Zero tables is allowed here: the managed-table set is resolved at startup from
+// the replicated coldfront.partition_config table, so a connection-only config
+// (no archiver.tables) is valid. archiver.tables is only an input to `import`;
+// the binaries fail loud when partition_config yields no rows.
 func (c *Config) validateTables(icebergMode bool) error {
 	for i, t := range c.Archiver.Tables {
 		if err := validateTable(t, i, icebergMode); err != nil {

--- a/internal/partcfg/commands.go
+++ b/internal/partcfg/commands.go
@@ -160,34 +160,62 @@ func runRegister(ctx context.Context, args []string) error {
 // ensures the config table, validates the PK covers the partition key, checks
 // the interval semantics, then INSERTs the row (or prints the dry-run summary).
 func registerToDB(ctx context.Context, connect func(context.Context) (*pgx.Conn, error), row configRow, dryRun bool) error {
-	twoLevel := row.subValues != ""
-	insertSQL := row.insertSQL()
 	conn, err := connect(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = conn.Close(ctx) }()
-	if err := EnsureTable(ctx, conn); err != nil {
+	// dry-run is side-effect free: skip the config-table DDL, just validate.
+	if !dryRun {
+		if err := EnsureTable(ctx, conn); err != nil {
+			return err
+		}
+	}
+	return writeRow(ctx, conn, row, dryRun)
+}
+
+// validateDB is a *pgx.Conn or pgx.Tx: the union of the query methods the row
+// validators need (Exec/Query via DBTX, QueryRow via RowQuerier).
+type validateDB interface {
+	DBTX
+	partition.RowQuerier
+}
+
+// validateRow is the ONE validation gate every partition_config write passes:
+// register, import, and set all run it, so no command can persist a row the
+// others would reject.
+//   - PK-superset: the cutover keys delta capture by the source PK, so the PK
+//     must cover the partition key column(s). 2-level adds the RANGE column (the
+//     LIST column comes from the catalog).
+//   - period validity + retention>hot ordering: PostgreSQL interval semantics,
+//     checked against the connection (the interval column type is the backstop).
+func validateRow(ctx context.Context, db validateDB, row configRow) error {
+	// After the archiver's first-run swap the source is a VIEW over "_"+name, so
+	// validate the PK / partition key against the real partitioned table. register
+	// runs pre-swap and resolves to the source unchanged, so every writer (register
+	// pre-swap, import/set post-swap) validates the same underlying table.
+	base := partition.ResolveSourceTable(ctx, db, row.schema, row.table)
+	if err := validatePKSuperset(ctx, db, row.schema, base, row.column, row.subValues != ""); err != nil {
 		return err
 	}
-	// PK-superset validation: the cutover keys delta capture by the source PK,
-	// so the PK must cover the partition key column(s). 2-level adds the RANGE
-	// column (the LIST column comes from the catalog).
-	if err := validatePKSuperset(ctx, conn, row.schema, row.table, row.column, twoLevel); err != nil {
+	return partition.ValidatePeriods(ctx, db, row.hot, row.retention)
+}
+
+// writeRow validates then inserts one table. register and import both call it
+// (import over a transaction, so a bulk import is all-or-nothing), so an imported
+// table is checked exactly as a singly-registered one. The caller has already
+// ensured the config table exists (skipped under dryRun, which writes nothing).
+func writeRow(ctx context.Context, db validateDB, row configRow, dryRun bool) error {
+	if err := validateRow(ctx, db, row); err != nil {
 		return err
 	}
-	// Period validity + retention>hot ordering are PostgreSQL interval semantics,
-	// so they're checked against the connection (fail fast at register time; the
-	// interval column type is the backstop for any direct write).
-	if err := partition.ValidatePeriods(ctx, conn, row.hot, row.retention); err != nil {
-		return err
-	}
+	insertSQL := row.insertSQL()
 	if dryRun {
 		fmt.Printf("dry-run OK: %s.%s validates; would run:\n%s\n", row.schema, row.table, insertSQL)
 		return nil
 	}
-	if _, err := conn.Exec(ctx, insertSQL); err != nil { // nosemgrep
-		return fmt.Errorf("register %s.%s: %w", row.schema, row.table, err)
+	if _, err := db.Exec(ctx, insertSQL); err != nil { // nosemgrep
+		return fmt.Errorf("write %s.%s: %w", row.schema, row.table, err)
 	}
 	fmt.Printf("registered %s.%s\n", row.schema, row.table)
 	return nil
@@ -578,7 +606,22 @@ EXAMPLES:
 		fmt.Println(sql)
 		return nil
 	}
-	return execSet(ctx, connect, *schema, *table, sql)
+	return execSet(ctx, connect, *schema, *table, sql, setTouchesValidatedField(fs))
+}
+
+// setTouchesValidatedField reports whether the `set` invocation changed a field
+// the shared validation covers (partition key, tier/drop ages, or the 2-level
+// source), so execSet knows to re-validate the resulting row rather than trust
+// the DB CHECK constraints alone.
+func setTouchesValidatedField(fs *flag.FlagSet) bool {
+	touched := false
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "column", "hot-period", "retention", "sub-values-source":
+			touched = true
+		}
+	})
+	return touched
 }
 
 // collectSetClauses walks the flags the user actually set (fs.Visit) and returns
@@ -595,7 +638,7 @@ func collectSetClauses(fs *flag.FlagSet, vals setVals) []string {
 
 // execSet connects, ensures the config table, and runs the UPDATE; a zero
 // row-count means the table isn't managed.
-func execSet(ctx context.Context, connect func(context.Context) (*pgx.Conn, error), schema, table, sql string) error {
+func execSet(ctx context.Context, connect func(context.Context) (*pgx.Conn, error), schema, table, sql string, validate bool) error {
 	conn, err := connect(ctx)
 	if err != nil {
 		return err
@@ -604,14 +647,54 @@ func execSet(ctx context.Context, connect func(context.Context) (*pgx.Conn, erro
 	if err := EnsureTable(ctx, conn); err != nil {
 		return err
 	}
-	tag, err := conn.Exec(ctx, sql) // nosemgrep
+	if validate {
+		return execSetValidated(ctx, conn, schema, table, sql)
+	}
+	if err := execUpdate(ctx, conn, schema, table, sql); err != nil {
+		return err
+	}
+	fmt.Printf("updated %s.%s\n", schema, table)
+	return nil
+}
+
+// execSetValidated applies the UPDATE in a transaction, re-reads the resulting
+// row, and runs the shared validation; a change that would leave the row invalid
+// rolls back.
+func execSetValidated(ctx context.Context, conn *pgx.Conn, schema, table, sql string) error {
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := execUpdate(ctx, tx, schema, table, sql); err != nil {
+		return err
+	}
+	row, found, err := loadRow(ctx, tx, schema, table)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("%s.%s is not managed (no partition_config row)", schema, table)
+	}
+	if err := validateRow(ctx, tx, rowFrom(row)); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	fmt.Printf("updated %s.%s\n", schema, table)
+	return nil
+}
+
+// execUpdate runs the SET UPDATE and errors if no managed row matched.
+func execUpdate(ctx context.Context, db DBTX, schema, table, sql string) error {
+	tag, err := db.Exec(ctx, sql) // nosemgrep
 	if err != nil {
 		return fmt.Errorf("set %s.%s: %w", schema, table, err)
 	}
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("%s.%s is not managed (no partition_config row)", schema, table)
 	}
-	fmt.Printf("updated %s.%s\n", schema, table)
 	return nil
 }
 
@@ -666,8 +749,7 @@ EXAMPLES:
 	return nil
 }
 
-// runImport seeds partition_config from a deployment YAML's archiver.tables —
-// the migration path off the YAML deprecation bridge.
+// runImport seeds partition_config from a deployment YAML's archiver.tables list.
 func runImport(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("import", flag.ContinueOnError)
 	cfgPath := fs.String("config", "", "deployment YAML to import: its archiver.tables become partition_config rows (required)")
@@ -676,16 +758,17 @@ func runImport(ctx context.Context, args []string) error {
 	dryRun := fs.Bool("dry-run", false, "validate/parse but make no changes")
 	fs.Usage = simpleUsage(fs, "import", `import — load a deployment YAML's archiver.tables into coldfront.partition_config.
 
-The migration path off the YAML bridge: register every table from an existing
-config file in one shot. Connection config (DSN, iceberg/S3) is NOT imported —
-it stays per-node.
+Register every table in a config file in one shot, each validated exactly as
+`+"`register`"+` validates a single table (PK covers the partition key; retention
+exceeds hot-period). Connection config (DSN, iceberg/S3) is NOT imported — it
+stays per-node.
 
 USAGE:
   <binary> import --config <yaml> [--dsn <dsn>]
 
 EXAMPLES:
-  partitioner import --config legacy.yaml                 # import its tables
-  partitioner import --config legacy.yaml --print-sql     # review the INSERTs first`)
+  partitioner import --config tables.yaml                 # import its tables
+  partitioner import --config tables.yaml --print-sql     # review the INSERTs first`)
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -700,9 +783,10 @@ EXAMPLES:
 	if len(cfg.Archiver.Tables) == 0 {
 		return fmt.Errorf("no archiver.tables in %s", *cfgPath)
 	}
-	stmts := buildImportStmts(cfg.Archiver.Tables)
 	if *printSQL {
-		printStmts(stmts)
+		for _, t := range cfg.Archiver.Tables {
+			fmt.Println(rowFrom(t).insertSQL())
+		}
 		return nil
 	}
 	d := *dsn
@@ -712,47 +796,48 @@ EXAMPLES:
 	if d == "" {
 		return fmt.Errorf("no DSN: set postgres.dsn in --config or pass --dsn")
 	}
-	return applyImport(ctx, d, cfg.Archiver.Tables, stmts, *dryRun)
+	return applyImport(ctx, d, cfg.Archiver.Tables, *dryRun)
 }
 
-// buildImportStmts renders one INSERT per table, index-aligned with tables so
-// the exec loop can name the failing table by the same index.
-func buildImportStmts(tables []config.TableConfig) []string {
-	stmts := make([]string, len(tables))
-	for i, t := range tables {
-		stmts[i] = rowFrom(t).insertSQL()
-	}
-	return stmts
-}
-
-func printStmts(stmts []string) {
-	for _, s := range stmts {
-		fmt.Println(s)
-	}
-}
-
-// applyImport connects, ensures the config table, then runs the import INSERTs
-// (or prints the dry-run summary). tables and stmts must stay index-aligned so a
-// failure names the right table.
-func applyImport(ctx context.Context, dsn string, tables []config.TableConfig, stmts []string, dryRun bool) error {
+// applyImport connects, ensures the config table, then writes every table
+// through writeRow — the same validated path `register` uses, so an imported
+// table is checked exactly as a singly-registered one (PK superset, retention
+// > hot). A failure names the offending table and stops the import.
+func applyImport(ctx context.Context, dsn string, tables []config.TableConfig, dryRun bool) error {
 	conn, err := openConn(ctx, dsn)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = conn.Close(ctx) }()
+	// dry-run is side-effect free: validate every table, touch nothing.
+	if dryRun {
+		for _, t := range tables {
+			if err := writeRow(ctx, conn, rowFrom(t), true); err != nil {
+				return fmt.Errorf("import %s: %w", t.SourceTable, err)
+			}
+		}
+		fmt.Printf("dry-run OK: would import %d table(s) into coldfront.partition_config\n", len(tables))
+		return nil
+	}
 	if err := EnsureTable(ctx, conn); err != nil {
 		return err
 	}
-	if dryRun {
-		fmt.Printf("dry-run OK: would import %d table(s)\n", len(stmts))
-		return nil
+	// One transaction for the whole import: a failure on any table rolls back the
+	// earlier inserts, so a bulk import never leaves partial config behind.
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return err
 	}
-	for i, s := range stmts {
-		if _, err := conn.Exec(ctx, s); err != nil {
-			return fmt.Errorf("import %s: %w", tables[i].SourceTable, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+	for _, t := range tables {
+		if err := writeRow(ctx, tx, rowFrom(t), false); err != nil {
+			return fmt.Errorf("import %s: %w", t.SourceTable, err)
 		}
 	}
-	fmt.Printf("imported %d table(s) into coldfront.partition_config\n", len(stmts))
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	fmt.Printf("imported %d table(s) into coldfront.partition_config\n", len(tables))
 	return nil
 }
 

--- a/internal/partcfg/partcfg.go
+++ b/internal/partcfg/partcfg.go
@@ -117,33 +117,47 @@ const (
 	PartitionOnly              // partitioner — hot_period IS NULL
 )
 
-// ResolveTables returns the managed-table set the caller owns: it ensures the
-// table exists, then returns the partition_config rows matching own if there are
-// any, else the supplied YAML fallback (the deprecation bridge for not-yet-
-// migrated deployments). The bool is true when the YAML fallback was used.
-// Callers fail loud if the result is empty (both sources empty).
-func ResolveTables(ctx context.Context, db DBTX, yamlFallback []config.TableConfig, own owner) ([]config.TableConfig, bool, error) {
+// ResolveTables returns the enabled managed tables the caller owns from the
+// replicated coldfront.partition_config table, the single source of truth for
+// the managed-table set. Provision it with `register` (one table) or `import`
+// (a YAML archiver.tables list); both write it through the same validation.
+// Returns an empty slice when nothing matches; callers fail loud.
+func ResolveTables(ctx context.Context, db DBTX, own owner) ([]config.TableConfig, error) {
 	if err := EnsureTable(ctx, db); err != nil {
-		return nil, false, err
+		return nil, err
 	}
-	rows, err := LoadTables(ctx, db, own)
+	return LoadTables(ctx, db, own)
+}
+
+// tableConfigColumns is the partition_config projection scanned by
+// scanTableConfig, shared by LoadTables and loadRow so the column order stays
+// in lockstep with the scan.
+const tableConfigColumns = `schema_name, table_name, partition_period, partition_column,
+	future_partitions, part_mode, id_scheme, hot_period::text,
+	retention_period::text, sub_part_values_source, expiration_strategy`
+
+// loadRow returns the single partition_config row for schema.table, with
+// found=false when no such row exists. Ownership-agnostic (used to re-read a row
+// mid-transaction for validation).
+func loadRow(ctx context.Context, db DBTX, schema, table string) (config.TableConfig, bool, error) {
+	rows, err := db.Query(ctx, `SELECT `+tableConfigColumns+`
+		FROM coldfront.partition_config WHERE schema_name=$1 AND table_name=$2`, schema, table)
 	if err != nil {
-		return nil, false, err
+		return config.TableConfig{}, false, fmt.Errorf("query partition_config: %w", err)
 	}
-	if len(rows) > 0 {
-		return rows, false, nil
+	defer rows.Close()
+	if !rows.Next() {
+		return config.TableConfig{}, false, rows.Err()
 	}
-	return yamlFallback, true, nil
+	t, err := scanTableConfig(rows)
+	return t, err == nil, err
 }
 
 // LoadTables reads the enabled partition_config rows the caller owns into the
 // existing config.TableConfig shape, so every downstream consumer is unchanged.
 // own filters by the hot_period ownership switch (see owner); AllOwners loads all.
 func LoadTables(ctx context.Context, db DBTX, own owner) ([]config.TableConfig, error) {
-	rows, err := db.Query(ctx, `
-		SELECT schema_name, table_name, partition_period, partition_column,
-		       future_partitions, part_mode, id_scheme, hot_period::text,
-		       retention_period::text, sub_part_values_source, expiration_strategy
+	rows, err := db.Query(ctx, `SELECT `+tableConfigColumns+`
 		FROM coldfront.partition_config
 		WHERE enabled
 		  AND CASE $1::int

--- a/internal/partcfg/partcfg_test.go
+++ b/internal/partcfg/partcfg_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
-
-	"github.com/pgedge/coldfront/internal/config"
 )
 
 type mockRows struct {
@@ -76,7 +74,7 @@ func TestEnsureTable(t *testing.T) {
 
 func emptyRows() (pgx.Rows, error) { return &mockRows{}, nil }
 
-func TestResolveTables_DBWins(t *testing.T) {
+func TestResolveTables_ReturnsDBRows(t *testing.T) {
 	db := &mockDB{rowsFunc: func() (pgx.Rows, error) {
 		return &mockRows{rows: []func(dest ...any) error{
 			func(dest ...any) error {
@@ -91,32 +89,13 @@ func TestResolveTables_DBWins(t *testing.T) {
 			},
 		}}, nil
 	}}
-	yaml := []config.TableConfig{{SourceTable: "from_yaml"}}
 	// The row is partition-only (hot NULL), so the partitioner owns it.
-	got, fromYAML, err := ResolveTables(context.Background(), db, yaml, PartitionOnly)
+	got, err := ResolveTables(context.Background(), db, PartitionOnly)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if fromYAML {
-		t.Fatal("expected DB rows to win, got YAML fallback")
 	}
 	if len(got) != 1 || got[0].SourceTable != "events" {
 		t.Fatalf("expected the DB row, got %+v", got)
-	}
-}
-
-func TestResolveTables_YAMLFallback(t *testing.T) {
-	db := &mockDB{rowsFunc: emptyRows} // no partition_config rows
-	yaml := []config.TableConfig{{SourceTable: "from_yaml"}}
-	got, fromYAML, err := ResolveTables(context.Background(), db, yaml, PartitionOnly)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !fromYAML {
-		t.Fatal("expected YAML fallback when the table is empty")
-	}
-	if len(got) != 1 || got[0].SourceTable != "from_yaml" {
-		t.Fatalf("expected the YAML fallback, got %+v", got)
 	}
 }
 
@@ -212,19 +191,16 @@ func TestLoadTables_PassesOwnerFilter(t *testing.T) {
 	}
 }
 
-// TestResolveTables_NoRowsFallsBackToYAML — when the binary's filtered query
-// returns nothing (an empty table, or only rows owned by the other binary),
-// ResolveTables falls back to the deprecated YAML bridge, exactly as it does for
-// an empty table today. The filter runs in SQL, so an empty result is
-// indistinguishable from an empty table here.
-func TestResolveTables_NoRowsFallsBackToYAML(t *testing.T) {
+// TestResolveTables_EmptyWhenNoRows — partition_config is the only source: an
+// empty table (or a result the owner filter empties out, indistinguishable in
+// SQL) yields an empty slice and no error. Callers fail loud on empty.
+func TestResolveTables_EmptyWhenNoRows(t *testing.T) {
 	db := &mockDB{rowsFunc: emptyRows}
-	yaml := []config.TableConfig{{SourceTable: "from_yaml"}}
-	got, fromYAML, err := ResolveTables(context.Background(), db, yaml, Tiered)
+	got, err := ResolveTables(context.Background(), db, Tiered)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !fromYAML || len(got) != 1 || got[0].SourceTable != "from_yaml" {
-		t.Fatalf("expected YAML fallback when the filtered query is empty, got fromYAML=%v %+v", fromYAML, got)
+	if len(got) != 0 {
+		t.Fatalf("expected empty result when partition_config has no rows, got %+v", got)
 	}
 }


### PR DESCRIPTION
Table config could previously come from two places — the `coldfront.partition_config` table, or a YAML `archiver.tables` block read as a runtime fallback — which could disagree and conflict (and on a mesh, `partition_config` replicates while per-node YAML does not). This removes that ambiguity: the binaries read table config only from `partition_config`, and `register`, `import`, and `set` all write it through the same validation (PK covers the partition key; `retention > hot`), now correct on post-swap views too. `register` is the recommended way to configure a table; `import`/`export` are bulk helpers for (re)configuring a machine.

Fixes #37.