### PR TITLE
fix: match bakery acks by spock node name, drop snowflake.node hash coupling

### DIFF
--- a/docker-compose.mesh-azure.yml
+++ b/docker-compose.mesh-azure.yml
@@ -1,6 +1,6 @@
 # 3-node Spock mesh on the DuckDB 1.5.x (Azure ADLS) image — the mesh counterpart
 # of docker-compose.matrix-azure.yml. Same topology as docker-compose.mesh.yml
-# (db1/db2/db3, MESH=on, snowflake nodes 691/109/672, Lakekeeper on its own PG)
+# (db1/db2/db3, MESH=on, snowflake nodes 1/2/3, Lakekeeper on its own PG)
 # but the cold store is Azure ADLS Gen2, so:
 #   - the db nodes use the pre-built coldfront-duckdb15:pg<major> image (azure +
 #     iceberg 1.5.x extensions), NOT the stock build: stage,
@@ -15,8 +15,9 @@
 # Build the image first: docker build -f docker/Dockerfile.duckdb15 \
 #   --build-arg PG_MAJOR=18 -t coldfront-duckdb15:pg18 .
 #
-# snowflake.node MUST equal hashtext(<spock node name>) & 1023 — db1→691,
-# db2→109, db3→672 (identical to docker-compose.mesh.yml; same hostnames).
+# COLDFRONT_SNOWFLAKE_NODE is any per-node UNIQUE integer 1..1023 (uniqueness
+# required, value otherwise arbitrary — the bakery matches acks by spock node
+# name, not by id); identical to docker-compose.mesh.yml.
 services:
   db1:
     image: coldfront-duckdb15:pg${PG_MAJOR:-18}
@@ -24,7 +25,7 @@ services:
     environment:
       PG_MAJOR: "${PG_MAJOR:-18}"
       MESH: "on"
-      COLDFRONT_SNOWFLAKE_NODE: "691"
+      COLDFRONT_SNOWFLAKE_NODE: "1"
       COLDFRONT_WAREHOUSE: wh-azure
       COLDFRONT_LAKEKEEPER: http://lakekeeper:8181/catalog
     healthcheck:
@@ -39,7 +40,7 @@ services:
     environment:
       PG_MAJOR: "${PG_MAJOR:-18}"
       MESH: "on"
-      COLDFRONT_SNOWFLAKE_NODE: "109"
+      COLDFRONT_SNOWFLAKE_NODE: "2"
       COLDFRONT_WAREHOUSE: wh-azure
       COLDFRONT_LAKEKEEPER: http://lakekeeper:8181/catalog
     healthcheck:
@@ -54,7 +55,7 @@ services:
     environment:
       PG_MAJOR: "${PG_MAJOR:-18}"
       MESH: "on"
-      COLDFRONT_SNOWFLAKE_NODE: "672"
+      COLDFRONT_SNOWFLAKE_NODE: "3"
       COLDFRONT_WAREHOUSE: wh-azure
       COLDFRONT_LAKEKEEPER: http://lakekeeper:8181/catalog
     healthcheck:

--- a/docker-compose.mesh.yml
+++ b/docker-compose.mesh.yml
@@ -10,9 +10,9 @@
 # (node_create + 6 bidirectional subs), then runs the journey + mesh stories
 # against db1. Lakekeeper runs on its OWN dedicated Postgres (never a data node).
 #
-# snowflake.node MUST equal hashtext(<spock node name>) & 1023 — the bakery's
-# dead-peer reap maps snowflake.get_node(ticket) back to a pg_stat_replication
-# peer. db1→691, db2→109, db3→672 (hashtext('dbN') & 1023).
+# COLDFRONT_SNOWFLAKE_NODE is any per-node UNIQUE integer 1..1023. Uniqueness is
+# required (snowflake ids and the bakery's per-node identity); the value is
+# otherwise arbitrary — the bakery matches acks by spock node name, not by id.
 services:
   db1:
     build: { context: ., dockerfile: docker/Dockerfile.duckdb15, args: { PG_MAJOR: "${PG_MAJOR:-18}" } }
@@ -20,7 +20,7 @@ services:
     environment:
       PG_MAJOR: "${PG_MAJOR:-18}"
       MESH: "on"
-      COLDFRONT_SNOWFLAKE_NODE: "691"
+      COLDFRONT_SNOWFLAKE_NODE: "1"
       COLDFRONT_WAREHOUSE: wh
       COLDFRONT_LAKEKEEPER: http://lakekeeper:8181/catalog
     healthcheck:
@@ -35,7 +35,7 @@ services:
     environment:
       PG_MAJOR: "${PG_MAJOR:-18}"
       MESH: "on"
-      COLDFRONT_SNOWFLAKE_NODE: "109"
+      COLDFRONT_SNOWFLAKE_NODE: "2"
       COLDFRONT_WAREHOUSE: wh
       COLDFRONT_LAKEKEEPER: http://lakekeeper:8181/catalog
     healthcheck:
@@ -50,7 +50,7 @@ services:
     environment:
       PG_MAJOR: "${PG_MAJOR:-18}"
       MESH: "on"
-      COLDFRONT_SNOWFLAKE_NODE: "672"
+      COLDFRONT_SNOWFLAKE_NODE: "3"
       COLDFRONT_WAREHOUSE: wh
       COLDFRONT_LAKEKEEPER: http://lakekeeper:8181/catalog
     healthcheck:

--- a/docs/architecture_decoupled.md
+++ b/docs/architecture_decoupled.md
@@ -281,9 +281,9 @@ PG nodes pointing at the same Lakekeeper endpoint and S3 bucket.
 
   - `coldfront.claims` - each writer inserts `(iceberg_table, ticket)`
     here; deleted on release.
-  - `coldfront.claim_acks` - peers insert `(ticket, ack_from_node,
-    iceberg_table)` to acknowledge an originator's claim. Replicates
-    back to the originator.
+  - `coldfront.claim_acks` - peers insert `(ticket, ack_from_name,
+    iceberg_table)` to acknowledge an originator's claim, keyed by the
+    acker's spock node name. Replicates back to the originator.
 
   Locally on every node, `coldfront.deferred_acks` queues acks the
   node has *deferred* because it has its own pending claim with a
@@ -373,10 +373,10 @@ wal_receiver_status_interval = 1s
 ```
 
 ```ini
-# postgresql.conf — per-node. snowflake.node MUST equal
-# (hashtext(<spock node_name>) & 1023) or the bakery raises at first claim:
-# it maps each ticket back to a spock node_name via the same hash for
-# dead-peer detection.
+# postgresql.conf — per-node. snowflake.node is any integer 1..1023, unique per
+# node; the value is otherwise arbitrary. The bakery matches acks by spock node
+# name (dead-peer detection joins claim_acks.ack_from_name to spock.node), so it
+# imposes no relationship between snowflake.node and the node name.
 snowflake.node = 1     # node1
 # snowflake.node = 2   # node2
 # snowflake.node = 3   # node3

--- a/docs/formal/Bakery_v2.tla
+++ b/docs/formal/Bakery_v2.tla
@@ -169,7 +169,10 @@ variables
   \* Acks received per ticket.  A pair <<t, nd>> in `acks` means peer NODE
   \* nd has acked the claim with ticket t.  Models coldfront.claim_acks
   \* (on the originator side, fully populated via spock replication of
-  \* peer-emitted ack rows).
+  \* peer-emitted ack rows).  `nd` is the node's identity: the concrete
+  \* claim_acks row carries the acker's spock node NAME (unique per node),
+  \* so the ack-wait match is a direct name equality with no id/name or
+  \* hash resolution — the model's abstract node identity realised exactly.
   acks = {},
 
   \* Deferred acks: a triple <<nd, t, behind>> means node nd queued an

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -599,9 +599,8 @@ shared_preload_libraries = 'snowflake,spock,pg_duckdb,coldfront'
 # quiet period.  1 s leaves comfortable margin.
 wal_receiver_status_interval = 1s
 
-# Per-node — distinct integer 1..1023.  MUST equal
-# (hashtext(<spock node_name>) & 1023); the bakery alignment check raises
-# at first claim if these disagree.
+# Per-node — any distinct integer 1..1023 (must be unique per node; the value
+# is otherwise arbitrary — the bakery matches acks by spock node name, not by id).
 snowflake.node = 1
 
 # DSN used by the bakery's autonomous-tx claim INSERT/DELETE via dblink.

--- a/extension/coldfront/coldfront--1.0.sql
+++ b/extension/coldfront/coldfront--1.0.sql
@@ -1728,6 +1728,28 @@ CREATE FUNCTION coldfront.node_id() RETURNS int
 LANGUAGE sql STABLE AS
 $$ SELECT current_setting('snowflake.node')::int $$;
 
+-- The local node's spock node name — the bakery's cross-node identity (acks are
+-- keyed by it). spock.local_node has only node_id + node_local_interface (no
+-- node_name column), and an unqualified node_name in a subquery against it
+-- silently resolves to an OUTER query's column, so we join to spock.node to read
+-- the local name explicitly. plpgsql (not sql) so the spock references resolve at
+-- call time: CREATE EXTENSION succeeds on a vanilla (spock-absent) install, where
+-- the bakery is never armed and this is never called.
+CREATE FUNCTION coldfront._my_spock_node_name() RETURNS name
+LANGUAGE plpgsql STABLE AS $$
+DECLARE
+    v_name name;
+BEGIN
+    -- STRICT: fail clearly here if the local spock node is not configured
+    -- (no row) or ambiguous (more than one), rather than returning NULL and
+    -- surfacing later as an opaque claim_acks NOT NULL violation. No EXCEPTION
+    -- block, so no subtransaction (pg_duckdb rejects those).
+    SELECT ln.node_name INTO STRICT v_name
+      FROM spock.local_node l
+      JOIN spock.node ln ON ln.node_id = l.node_id;
+    RETURN v_name;
+END $$;
+
 -- ============================================================================
 -- Multi-writer commit serialisation (bakery protocol).
 --
@@ -1792,16 +1814,17 @@ CREATE TABLE coldfront.claims (
 );
 
 -- Acks for the bakery's Ricart-Agrawala layer.  A row here means
--- "peer ack_from_node has acknowledged ticket on iceberg_table."  The
+-- "peer ack_from_name (its spock node name) has acknowledged ticket on
+-- iceberg_table."  The
 -- originator polls this table waiting for one row per live peer before
 -- entering the iceberg-commit phase.  Spock-replicated so peers'
 -- ack-INSERTs (from the peer-side trigger on coldfront.claims) reach
 -- the originator.
 CREATE TABLE coldfront.claim_acks (
     ticket          bigint NOT NULL,
-    ack_from_node   int    NOT NULL,
+    ack_from_name   name   NOT NULL,
     iceberg_table   text   NOT NULL,
-    PRIMARY KEY (ticket, ack_from_node)
+    PRIMARY KEY (ticket, ack_from_name)
 );
 
 -- Deferred acks queue, LOCAL to each node (NOT replicated).  When a peer
@@ -1883,6 +1906,7 @@ CREATE FUNCTION coldfront._on_claim_apply() RETURNS trigger
 LANGUAGE plpgsql AS $$
 DECLARE
     my_node         int    := current_setting('snowflake.node')::int;
+    my_name         name   := coldfront._my_spock_node_name();
     connstr         text   := coldfront._dblink_self_connstr();
     -- Per-table advisory lock key. Pairs with the exclusive lock that
     -- _claim_iceberg_lock takes around its dblink-INSERT. Shared mode
@@ -1955,9 +1979,9 @@ BEGIN
             PERFORM public.dblink_connect('coldfront_self', connstr);
         END IF;
         PERFORM public.dblink_exec('coldfront_self', format(
-            'INSERT INTO coldfront.claim_acks (ticket, ack_from_node, iceberg_table) '
-            'VALUES (%s, %s, %L) ON CONFLICT DO NOTHING',
-            NEW.ticket, my_node, NEW.iceberg_table));
+            'INSERT INTO coldfront.claim_acks (ticket, ack_from_name, iceberg_table) '
+            'VALUES (%s, %L, %L) ON CONFLICT DO NOTHING',
+            NEW.ticket, my_name, NEW.iceberg_table));
     END IF;
     RETURN NULL;
 END $$;
@@ -1978,13 +2002,14 @@ CREATE FUNCTION coldfront._on_claim_release() RETURNS trigger
 LANGUAGE plpgsql AS $$
 DECLARE
     my_node int := current_setting('snowflake.node')::int;
+    my_name name := coldfront._my_spock_node_name();
 BEGIN
     IF snowflake.get_node(OLD.ticket) <> my_node THEN
         RETURN NULL;
     END IF;
 
-    INSERT INTO coldfront.claim_acks (ticket, ack_from_node, iceberg_table)
-    SELECT ack_for_ticket, my_node, iceberg_table
+    INSERT INTO coldfront.claim_acks (ticket, ack_from_name, iceberg_table)
+    SELECT ack_for_ticket, my_name, iceberg_table
       FROM coldfront.deferred_acks
      WHERE pending_ticket = OLD.ticket
     ON CONFLICT DO NOTHING;
@@ -2017,18 +2042,9 @@ CREATE FUNCTION coldfront._claim_iceberg_lock(
 DECLARE
     connstr           text     := coldfront._dblink_self_connstr();
     my_node           int      := current_setting('snowflake.node')::int;
-    -- Real local spock node name. spock.local_node has only node_id +
-    -- node_local_interface (no node_name column) — an unqualified
-    -- node_name in a subquery against it silently resolves to the
-    -- OUTER query's column (e.g. n.node_name in the alive-check below),
-    -- so we explicitly join to spock.node to read the local name.
-    -- Without this fix the alive-check generates slot names with the
-    -- peer's node as "local", never matching any walsender, and every
-    -- peer is treated as dead → bakery skips required acks → race.
-    my_node_name      name     := (
-        SELECT ln.node_name FROM spock.local_node l
-          JOIN spock.node ln ON ln.node_id = l.node_id
-    );
+    -- Local spock node name, used for the ack-wait join and the liveness
+    -- slot-name computation (see coldfront._my_spock_node_name).
+    my_node_name      name     := coldfront._my_spock_node_name();
     my_ticket         bigint;
     -- Per-table advisory lock key (pairs with the shared lock taken in
     -- _on_claim_apply). Held EXCLUSIVELY in THIS session ONLY across
@@ -2072,20 +2088,6 @@ BEGIN
             'SET statement_timeout = ''30s''');
     END IF;
 
-    -- Alignment precondition: snowflake.node = hashtext(spock node name)
-    -- & 1023.  Needed because the dead-peer detection in the ack-wait
-    -- loop maps each peer's snowflake.node back to a spock.node_name
-    -- via the same hash.  Cached per-session.
-    IF current_setting('coldfront._snowflake_aligned', true) IS DISTINCT FROM 'true' THEN
-        PERFORM 1
-           FROM spock.local_node l JOIN spock.node n ON n.node_id = l.node_id
-          WHERE (hashtext(n.node_name::text) & 1023) = my_node;
-        IF NOT FOUND THEN
-            RAISE EXCEPTION 'coldfront: snowflake.node = % does not match hashtext(local spock node name) & 1023; reconfigure snowflake.node in postgresql.conf and restart',
-                            my_node;
-        END IF;
-        PERFORM set_config('coldfront._snowflake_aligned', 'true', false);
-    END IF;
 
     -- NodeStartup self-cleanup of pre-restart orphans.  Cheap when no
     -- orphans exist (gated on a local EXISTS).
@@ -2150,7 +2152,7 @@ BEGIN
                AND NOT EXISTS (
                  SELECT 1 FROM coldfront.claim_acks a
                   WHERE a.ticket = my_ticket
-                    AND a.ack_from_node = (hashtext(n.node_name) & 1023)
+                    AND a.ack_from_name = n.node_name
                )
                AND EXISTS (
                  -- Per-peer alive check: match the walsender on us serving


### PR DESCRIPTION
The bakery required `snowflake.node = hashtext(<spock node name>) & 1023`. That check ran per-node only, so two node names hashing to the same value slipped through, and a duplicate id then corrupted the protocol.

Now each acknowledgement is recorded under the acking node's spock **node name** (in `coldfront.claim_acks`) and matched by name directly. There is no deriving the id from the name, so the hash check is dropped and `snowflake.node` can be any integer that is unique per node.