### PR TITLE
fix: reject oid columns as unsupported

### DIFF
--- a/ci/journey.sh
+++ b/ci/journey.sh
@@ -524,11 +524,15 @@ EOSQL
 )
     assert_eq "cold-INSERT-via-trigger bytea stored natively (2 bytes)" "2" "$(extract COLDINS_LEN "$CI")"
 
-    # inet/cidr are rejected at provisioning — no cast makes them readable
+    # inet/cidr/oid are rejected at provisioning: no cast makes them readable
     # through pg_duckdb once the table is Iceberg-backed. Match the specific
     # rejection text, not just the type name (which the input itself contains).
     local IE; IE=$(q_may "$HOST" "SELECT coldfront.create_iceberg_table('public','ip_reject','[{\"name\":\"a\",\"type\":\"inet\"}]'::jsonb);")
     assert_contains "inet rejected at provisioning" "store IP data as text" "$IE"
+    # oid archives but its column is unreadable through the pg_duckdb-planned
+    # view after cutover, so it is rejected up front like inet; use bigint.
+    local OE; OE=$(q_may "$HOST" "SELECT coldfront.create_iceberg_table('public','oid_reject','[{\"name\":\"a\",\"type\":\"oid\"}]'::jsonb);")
+    assert_contains "oid rejected at provisioning" "oid values as bigint" "$OE"
 }
 
 # ───────────────────────────────────────────────────────────────────────────

--- a/cmd/archiver/main.go
+++ b/cmd/archiver/main.go
@@ -1369,9 +1369,9 @@ func pgFormatTypeToDuckDB(s string) (storage, viewCastType string, err error) {
 		"PG type %q has no Iceberg-compatible mapping. Supported: bigint, integer, "+
 			"smallint, real, double precision, boolean, timestamp with/without time "+
 			"zone, date, time without time zone, uuid, text, character varying(N), "+
-			"character(N), bytea, numeric(P,S) with P<=38, json, jsonb, interval, "+
-			"oid. inet/cidr are not supported (pg_duckdb cannot process inet in "+
-			"Iceberg-backed queries); store IP data as text", s)
+			"character(N), bytea, numeric(P,S) with P<=38, json, jsonb, interval. "+
+			"inet/cidr/oid are not supported (pg_duckdb cannot process them in "+
+			"Iceberg-backed queries): store IP data as text and oid values as bigint", s)
 }
 
 // pgTypeMap holds the 1:1 PG-format_type → (storage, viewCast) mappings used by
@@ -1381,8 +1381,8 @@ var pgTypeMap = map[string]struct{ storage, viewCast string }{
 	// Numeric / boolean — storage matches surface; no cast needed.
 	"bigint":  {"BIGINT", ""},
 	"integer": {"INTEGER", ""},
-	// Iceberg has no 16-bit integer; widen to INTEGER (lossless, same as oid →
-	// BIGINT). duckdb-iceberg rejects SMALLINT at CREATE TABLE. No view cast
+	// Iceberg has no 16-bit integer; widen to INTEGER (lossless). duckdb-iceberg
+	// rejects SMALLINT at CREATE TABLE. No view cast
 	// needed: INTEGER is itself a PG-parseable surface, and the view casts BOTH
 	// branches to the storage type, so bootstrap (hot-only) and post-cutover
 	// (hot+cold) views agree on the column type.
@@ -1408,13 +1408,6 @@ var pgTypeMap = map[string]struct{ storage, viewCast string }{
 	// Iceberg/DuckDB storage is BLOB, which is not a PG-parseable cast name;
 	// surface via the PG-spelled "bytea" on both branches.
 	"bytea": {"BLOB", "bytea"},
-
-	// PG `oid` is 4-byte unsigned (max 4_294_967_295). DuckDB INTEGER is signed
-	// 32-bit, so values above 2_147_483_647 would overflow; widen to BIGINT for
-	// safe round-trip. No view cast: BIGINT is a PG-parseable surface and the
-	// view casts both branches to the storage type, so bootstrap/cutover view
-	// types agree.
-	"oid": {"BIGINT", ""},
 
 	// Iceberg has no JSON primitive — storage VARCHAR, surface json.
 	"jsonb": {"VARCHAR", "json"},

--- a/cmd/archiver/main_test.go
+++ b/cmd/archiver/main_test.go
@@ -168,7 +168,6 @@ func TestPgFormatTypeToDuckDB(t *testing.T) {
 		{pg: "character varying", wantStorage: "VARCHAR"},
 		{pg: "character(10)", wantStorage: "VARCHAR"},
 		{pg: "bytea", wantStorage: "BLOB", wantViewCastTyp: "bytea"}, // BLOB not PG-parseable
-		{pg: "oid", wantStorage: "BIGINT"},                           // widened; BIGINT is its own surface
 		{pg: "numeric(20,5)", wantStorage: "DECIMAL(20,5)"},
 		{pg: "numeric(38, 10)", wantStorage: "DECIMAL(38,10)"},
 
@@ -177,11 +176,13 @@ func TestPgFormatTypeToDuckDB(t *testing.T) {
 		{pg: "json", wantStorage: "VARCHAR", wantViewCastTyp: "json"},
 		{pg: "interval", wantStorage: "VARCHAR", wantViewCastTyp: "interval"},
 
-		// Errors. inet/cidr are rejected: pg_duckdb cannot process inet (Oid
-		// 869) in an Iceberg-backed query, and every tiered read is planned by
-		// pg_duckdb, so there is no cast that makes them readable.
+		// Errors. inet/cidr/oid are rejected: pg_duckdb cannot process them in
+		// an Iceberg-backed query, and every tiered read is planned by pg_duckdb,
+		// so there is no cast that makes them readable (oid would archive fine but
+		// its column becomes unreadable through the view after cutover).
 		{pg: "inet", wantErr: true},
 		{pg: "cidr", wantErr: true},
+		{pg: "oid", wantErr: true},
 		{pg: "numeric", wantErr: true},
 		{pg: "time with time zone", wantErr: true},
 		{pg: "tsvector", wantErr: true},

--- a/docs/architecture_decoupled.md
+++ b/docs/architecture_decoupled.md
@@ -131,7 +131,6 @@ surface are:
 | `date` / `time without time zone` | `DATE` / `TIME` | identical |
 | `uuid` | `UUID` | identical |
 | `bytea` | `BLOB` | identical |
-| `oid` | `BIGINT` (signed-safe widen) | identical |
 | `text` / `varchar(N)` / `char(N)` | `VARCHAR` | unbounded; declared length not enforced; `char(N)` returns unpadded (`pg_typeof varchar`) |
 | `numeric(P,S)` (P ≤ 38) | `DECIMAL(P,S)` | identical |
 | `jsonb` / `json` | `VARCHAR` | view-cast back to `json` (not `jsonb` - Iceberg has no JSON primitive) |
@@ -140,9 +139,10 @@ surface are:
 Rejected (rather than silently downgraded to `VARCHAR` and losing
 precision/identity):
 
-- `inet` / `cidr` - pg_duckdb cannot process PG `inet` (Oid 869) in any
-  query it plans, and every Iceberg-backed read is planned by
-  pg_duckdb. No cast makes them readable; store IP data as `text`.
+- `inet` / `cidr` / `oid` - pg_duckdb cannot process them (`inet` Oid 869,
+  `oid` Oid 26) in any query it plans, and every Iceberg-backed read is
+  planned by pg_duckdb. No cast makes them readable; store IP data as
+  `text` and `oid` values as `bigint`.
 - `numeric` without explicit `(P,S)` - Iceberg requires bounded decimals.
 - Custom enums, `xml`, `tsvector`/`tsquery`, range types, multirange types.
 - Composite types and arrays. (Arrays would map to Parquet `LIST<…>`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -549,7 +549,7 @@ The following PostgreSQL column types are supported:
 `bigint` · `integer` · `smallint` · `real` · `double precision` ·
 `boolean` · `timestamp with time zone` · `timestamp without time zone` ·
 `date` · `time without time zone` · `uuid` · `text` · `varchar(N)` ·
-`char(N)` · `bytea` · `oid` · `numeric(P,S)` (P ≤ 38) · `jsonb` / `json` ·
+`char(N)` · `bytea` · `numeric(P,S)` (P ≤ 38) · `jsonb` / `json` ·
 `interval`
 
 Anything else (unbounded `numeric`, `xml`, `tsvector`, range/multirange
@@ -591,11 +591,11 @@ query skips DuckDB entirely. Such a read surfaces `data` as native
 cold-only, or reach the view through a join or sub-query stay in DuckDB,
 where the limits above apply.
 
-`inet`/`cidr` are **not supported**: pg_duckdb cannot process PG `inet`
-(Oid 869) in any Iceberg-backed query, and every cross-tier read is
-planned by pg_duckdb - so no cast makes them readable. Store IP data as
-`text` (you can still index/compare it; cast to `inet` in your own
-queries on the hot side only if needed).
+`inet`/`cidr`/`oid` are **not supported**: pg_duckdb cannot process them
+(`inet` Oid 869, `oid` Oid 26) in any Iceberg-backed query, and every
+cross-tier read is planned by pg_duckdb - so no cast makes them readable.
+Store IP data as `text` and `oid` values as `bigint` (you can still
+index/compare them; cast on the hot side only if needed).
 
 ## Gotchas
 

--- a/extension/coldfront/coldfront--1.0.sql
+++ b/extension/coldfront/coldfront--1.0.sql
@@ -1507,8 +1507,8 @@ BEGIN
     -- Numeric / boolean
     IF t IN ('bigint', 'int8')             THEN RETURN 'BIGINT';   END IF;
     IF t IN ('integer', 'int', 'int4')     THEN RETURN 'INTEGER';  END IF;
-    -- Iceberg has no 16-bit integer; widen smallint to INTEGER (lossless,
-    -- same principle as oid → BIGINT). duckdb-iceberg rejects SMALLINT outright.
+    -- Iceberg has no 16-bit integer; widen smallint to INTEGER (lossless).
+    -- duckdb-iceberg rejects SMALLINT outright.
     IF t IN ('smallint', 'int2')           THEN RETURN 'INTEGER';  END IF;
     IF t IN ('real', 'float4')             THEN RETURN 'REAL';     END IF;
     IF t IN ('double precision', 'float8') THEN RETURN 'DOUBLE';   END IF;
@@ -1522,7 +1522,6 @@ BEGIN
     IF t = 'uuid'  THEN RETURN 'UUID';    END IF;
     IF t = 'text'  THEN RETURN 'VARCHAR'; END IF;
     IF t = 'bytea' THEN RETURN 'BLOB';    END IF;
-    IF t = 'oid'   THEN RETURN 'BIGINT';  END IF;  -- 4-byte unsigned safe-widen
     -- Variable-precision strings
     IF t LIKE 'character varying%' OR t LIKE 'varchar%'
        OR t LIKE 'character(%' OR t LIKE 'char(%' OR t = 'character'
@@ -1536,12 +1535,12 @@ BEGIN
     END IF;
     -- View-cast types: stored as VARCHAR, surfaced via wrapper view as native PG type
     IF t IN ('jsonb', 'json', 'interval') THEN RETURN 'VARCHAR'; END IF;
-    -- inet/cidr are NOT supported: pg_duckdb rejects PG inet (Oid 869) in any
-    -- query it plans, and every Iceberg-backed view read is planned by
-    -- pg_duckdb, so there is no cast that makes them readable. Store IP data
-    -- as text instead.
+    -- inet/cidr/oid are NOT supported: pg_duckdb rejects them (inet Oid 869,
+    -- oid Oid 26) in any query it plans, and every Iceberg-backed view read is
+    -- planned by pg_duckdb, so no cast makes them readable. Store IP data as
+    -- text and oid values as bigint instead.
 
-    RAISE EXCEPTION 'coldfront: PG type % has no Iceberg-compatible mapping. Supported: bigint, integer, smallint, real, double precision, boolean, timestamptz, timestamp, date, time, uuid, text, varchar(N), char(N), bytea, oid, numeric(P,S), jsonb, json, interval. inet/cidr unsupported (store IP data as text)', p_pg_type;
+    RAISE EXCEPTION 'coldfront: PG type % has no Iceberg-compatible mapping. Supported: bigint, integer, smallint, real, double precision, boolean, timestamptz, timestamp, date, time, uuid, text, varchar(N), char(N), bytea, numeric(P,S), jsonb, json, interval. inet/cidr/oid unsupported (store IP data as text, oid values as bigint)', p_pg_type;
 END;
 $$;
 
@@ -1562,10 +1561,10 @@ LANGUAGE sql IMMUTABLE STRICT AS $$
         WHEN 'float8'           THEN 'double precision'
         -- BLOB is not a PG-parseable cast name; surface bytea via "bytea".
         WHEN 'bytea'            THEN 'bytea'
-        -- Everything else (incl. smallint→INTEGER, oid→BIGINT widening) has a
-        -- storage type that is itself a PG-parseable surface; the view casts
-        -- BOTH branches to that storage type, so no separate surface cast is
-        -- needed and bootstrap/post-cutover view column types still agree.
+        -- Everything else (incl. smallint→INTEGER widening) has a storage type
+        -- that is itself a PG-parseable surface; the view casts BOTH branches
+        -- to that storage type, so no separate surface cast is needed and
+        -- bootstrap/post-cutover view column types still agree.
         ELSE ''
     END;
 $$;

--- a/extension/coldfront/test/expected/ddl_alter_column.out
+++ b/extension/coldfront/test/expected/ddl_alter_column.out
@@ -26,8 +26,8 @@ VALUES ('public', 'events', 'public._events', 'ice.default.events', 'ts');
 -- 1. Unsupported column type is rejected up front (originator path), before any
 --    Iceberg I/O; the hot ALTER rolls back with it, so _events is unchanged.
 ALTER TABLE public._events ADD COLUMN bad inet;
-ERROR:  coldfront: PG type inet has no Iceberg-compatible mapping. Supported: bigint, integer, smallint, real, double precision, boolean, timestamptz, timestamp, date, time, uuid, text, varchar(N), char(N), bytea, oid, numeric(P,S), jsonb, json, interval. inet/cidr unsupported (store IP data as text)
-CONTEXT:  PL/pgSQL function _iceberg_storage_type(text) line 42 at RAISE
+ERROR:  coldfront: PG type inet has no Iceberg-compatible mapping. Supported: bigint, integer, smallint, real, double precision, boolean, timestamptz, timestamp, date, time, uuid, text, varchar(N), char(N), bytea, numeric(P,S), jsonb, json, interval. inet/cidr/oid unsupported (store IP data as text, oid values as bigint)
+CONTEXT:  PL/pgSQL function _iceberg_storage_type(text) line 41 at RAISE
 PL/pgSQL function _mirror_iceberg_alter(text,text,jsonb) line 36 at assignment
 SQL statement "SELECT coldfront._mirror_iceberg_alter('ice.default.events', 'public._events', jsonb_build_array(jsonb_build_object('op', 'add', 'col', 'bad')))"
 SELECT attname FROM pg_attribute


### PR DESCRIPTION
`oid` mapped to `BIGINT`, but pg_duckdb rejects the oid column reference at
plan time in any Iceberg-backed query (the same limit as inet/cidr), so an
oid column archived fine yet became unreadable through the tiered view after
cutover. It's now rejected at provisioning in both the archiver and the
extension, with guidance to store oid values as `bigint`.

Closes #51.
