### PR TITLE
Tier partitions in bound order and refuse to drop a non-empty partition

### DIFF
--- a/ci/journey.sh
+++ b/ci/journey.sh
@@ -2481,14 +2481,18 @@ EOF
 }
 
 # ───────────────────────────────────────────────────────────────────────────
-# Story — TC-024: an empty (0-row) partition archives cleanly through all six
-# phases (0–5). The partition must be created in the PUBLIC schema with an
-# explicit prefix — the coldfront user's search_path defaults to
+# Story: TC-024, an empty (0-row) partition over a range the cold tier already
+# covers is dropped cleanly and the run still exits 0. Every month past the hot
+# window on this table also sits below the watermark, so this exercises the
+# stale-partition cleanup branch; the drop is allowed precisely because the
+# partition holds no rows (story_partition_order_by_bound covers the non-empty
+# case, which is refused). The partition must be created in the PUBLIC schema
+# with an explicit prefix: the coldfront user's search_path defaults to
 # coldfront,public, so a bare CREATE TABLE lands in the coldfront schema and
-# the PK check (nspname='public') would find 0 primary-key columns.
+# the PK check (nspname='public') finds 0 primary-key columns.
 # ───────────────────────────────────────────────────────────────────────────
 story_empty_partition() {
-    step "TC-024: 0-row partition archives cleanly (all 6 phases, exit 0)"
+    step "TC-024: 0-row partition over an already-cold range is dropped (exit 0)"
     # In mesh mode cleanupAlreadyArchived fans out DETACH CONCURRENTLY to Spock
     # peers via their interface DSN; those hostnames are not resolvable from the
     # archiver host in the journey config. Skip here — same reason as
@@ -2510,8 +2514,7 @@ story_empty_partition() {
     else
         fail "TC-024: archiver failed on empty partition — see /tmp/journey-empty-part.log"; tail -8 /tmp/journey-empty-part.log
     fi
-    # Phase 5 drops the partition from PG after cutover.
-    assert_eq "TC-024: empty partition archived and dropped from PG" "0" \
+    assert_eq "TC-024: empty partition dropped from PG" "0" \
         "$(q "$HOST" "SELECT count(*) FROM pg_class WHERE relname='${pname}' AND relnamespace='public'::regnamespace;")"
 }
 
@@ -3279,15 +3282,6 @@ EOSQL
 # ───────────────────────────────────────────────────────────────────────────
 story_exotic_partition_bounds() {
     step "exotic partition bounds do not abort the archiver"
-    # The MINVALUE partition ends up below the watermark once the BC one
-    # archives, so it takes the cleanupAlreadyArchived path, whose peer detach
-    # needs peer DSNs the host-side archiver cannot resolve. Same reason TC-024
-    # skips here; bound parsing is topology-independent and the vanilla cells
-    # cover it.
-    if [ "$MESH" = 1 ]; then
-        note "exotic bounds: skipping in mesh mode (cleanupAlreadyArchived peer detach requires resolvable peer DSNs)"
-        return
-    fi
     local dsn="host=${DB_IP} port=5432 dbname=coldfront user=coldfront password=coldfront sslmode=disable"
     q "$HOST" "CREATE SCHEMA IF NOT EXISTS xb;" >/dev/null
     # Ascending, non-overlapping, all inside PostgreSQL's range (4713 BC to
@@ -3317,6 +3311,11 @@ EOSQL
     # MINVALUE and the year-20000 bound must not have stopped the pass.
     assert_contains "exotic bounds: the BC partition reached cutover" "archived events_bc" \
         "$(cat /tmp/journey-xb.log)"
+    # The open lower edge (MINVALUE) sorts LAST by name and FIRST by bound, so
+    # it pins the ordering contract: it is tiered on its bound, ahead of the BC
+    # partition whose cutover carries the watermark past its range.
+    assert_contains "exotic bounds: the MINVALUE partition tiered, not dropped as stale" \
+        "archived events_open_lo" "$(cat /tmp/journey-xb.log)"
 
     # A DEFAULT partition is refused outright at registration: its rows could
     # never tier or expire, and PostgreSQL blocks concurrent detach of every
@@ -3338,6 +3337,89 @@ EOSQL
     q "$HOST" "DELETE FROM coldfront.archive_watermark WHERE schema_name='xb';" >/dev/null 2>&1
     q "$HOST" "DELETE FROM coldfront.tiered_views      WHERE schema_name='xb';" >/dev/null 2>&1
     q "$HOST" "DROP SCHEMA xb CASCADE;" >/dev/null 2>&1
+}
+
+# ───────────────────────────────────────────────────────────────────────────
+# Story: partitions are tiered in bound order, whatever they are named, and a
+# stale-looking partition that still holds rows is refused, not dropped.
+#
+# The user names the initial partition set (the documented tiered workflow is to
+# bring your own RANGE-partitioned table and register it), and unpadded month
+# numbers sort "10" before "9". Each cutover advances the watermark to its own
+# partition's upper bound, so the tiering order has to follow the calendar for
+# every partition to be exported before its range goes cold.
+# ───────────────────────────────────────────────────────────────────────────
+story_partition_order_by_bound() {
+    step "partitions tier in bound order, not name order"
+    local dsn="host=${DB_IP} port=5432 dbname=coldfront user=coldfront password=coldfront sslmode=disable"
+    # Two aged months whose names sort against the calendar, seeded relative to
+    # now() so the split holds under any wall clock. now-4mo/now-3mo keeps the
+    # newer partition's upper bound at least 59 days old, so a 30-day hot window
+    # covers both on every calendar date. Ids are explicit so the story stays on
+    # the set-based cold-write path; ordering is the subject here.
+    qf "$HOST" <<'EOSQL' >/dev/null
+CREATE SCHEMA IF NOT EXISTS ord;
+CREATE TABLE IF NOT EXISTS ord.sales (
+    id bigint NOT NULL, ts timestamptz NOT NULL, amount numeric(10,2),
+    PRIMARY KEY (id, ts)
+) PARTITION BY RANGE (ts);
+DO $do$
+DECLARE older date := (date_trunc('month', now()) - interval '4 months')::date;
+        newer date := (date_trunc('month', now()) - interval '3 months')::date;
+BEGIN
+  -- Unpadded single-digit vs two-digit suffixes: "..._10" sorts before "..._9".
+  EXECUTE format('CREATE TABLE IF NOT EXISTS ord.%I PARTITION OF ord.sales FOR VALUES FROM (%L) TO (%L)',
+                 'sales_p_9',  older, newer);
+  EXECUTE format('CREATE TABLE IF NOT EXISTS ord.%I PARTITION OF ord.sales FOR VALUES FROM (%L) TO (%L)',
+                 'sales_p_10', newer, (newer + interval '1 month')::date);
+END $do$;
+INSERT INTO ord.sales (id, ts, amount) SELECT i, date_trunc('month',now()) - interval '4 months' + (i*interval '1 hour'), 1
+                                         FROM generate_series(1,70) i;
+INSERT INTO ord.sales (id, ts, amount) SELECT 1000+i, date_trunc('month',now()) - interval '3 months' + (i*interval '1 hour'), 1
+                                         FROM generate_series(1,50) i;
+EOSQL
+    assert_eq "bound order: seeded 120 rows across two aged partitions" "120" \
+        "$(q "$HOST" "SELECT count(*) FROM ord.sales;")"
+    "$PARTITIONER" register --dsn "$dsn" --schema ord --table sales \
+        --period monthly --hot-period "30 days" >/dev/null 2>&1
+    if archive_only "schema_name='ord' AND table_name='sales'" /tmp/journey-archiver.yaml /tmp/journey-ord.log; then
+        pass "bound order: archive cycle completed"
+    else
+        fail "bound order: archiver failed, see /tmp/journey-ord.log"; tail -8 /tmp/journey-ord.log
+    fi
+    # Both partitions must reach Iceberg. "archived" is logged only by the full
+    # export pipeline, so it distinguishes a real export from a stale-partition
+    # drop for the single-digit name that sorts last.
+    assert_contains "bound order: the name-last partition was exported" "archived sales_p_9" \
+        "$(cat /tmp/journey-ord.log)"
+    assert_contains "bound order: the name-first partition was exported" "archived sales_p_10" \
+        "$(cat /tmp/journey-ord.log)"
+    # The whole point: no row went missing across the tier move.
+    assert_eq "bound order: all 120 rows still readable through the view" "120" \
+        "$(q "$HOST" "SELECT count(*) FROM ord.sales;")"
+    assert_eq "bound order: the older month survived in the cold tier" "70" \
+        "$(q "$HOST" "SELECT count(*) FROM ord.sales WHERE ts < date_trunc('month',now()) - interval '3 months';")"
+
+    # A partition below the watermark that still holds rows is in neither tier,
+    # so the drop is refused and the rows survive: the DROP relies on direct
+    # evidence that the partition is empty, never on the watermark alone.
+    q "$HOST" "CREATE TABLE ord.sales_p_stale PARTITION OF ord._sales
+                 FOR VALUES FROM ('2001-01-01') TO ('2001-02-01');" >/dev/null
+    q "$HOST" "INSERT INTO ord.sales_p_stale (id, ts, amount) VALUES (9001, '2001-01-15', 1);" >/dev/null
+    if archive_only "schema_name='ord' AND table_name='sales'" /tmp/journey-archiver.yaml /tmp/journey-ord2.log; then
+        fail "bound order: archiver dropped a non-empty stale partition; it must refuse"
+    else
+        pass "bound order: archiver refused a non-empty partition below the watermark"
+    fi
+    assert_contains "bound order: the refusal names the partition and the remedy" \
+        "refusing to drop ord.sales_p_stale" "$(cat /tmp/journey-ord2.log)"
+    assert_eq "bound order: the unaccounted row was not destroyed" "1" \
+        "$(q "$HOST" "SELECT count(*) FROM ord.sales_p_stale;")"
+
+    q "$HOST" "DELETE FROM coldfront.partition_config  WHERE schema_name='ord';" >/dev/null 2>&1
+    q "$HOST" "DELETE FROM coldfront.archive_watermark WHERE schema_name='ord';" >/dev/null 2>&1
+    q "$HOST" "DELETE FROM coldfront.tiered_views      WHERE schema_name='ord';" >/dev/null 2>&1
+    q "$HOST" "DROP SCHEMA ord CASCADE;" >/dev/null 2>&1
 }
 
 # ───────────────────────────────────────────────────────────────────────────
@@ -3801,6 +3883,7 @@ if [ "$MODE" = "tiered" ]; then
     story_partition_col_date           # TC-067: date partition column
     story_partition_col_text_rejected  # TC-070: text partition column rejected at archive
     story_exotic_partition_bounds      # BC, wide years, open-ended and DEFAULT bounds
+    story_partition_order_by_bound     # tier in bound order; refuse a non-empty stale partition
     story_schema_collision             # TC-138: same table name in two schemas — distinct Iceberg namespaces
     story_pg_restart                   # TC-063: PG restart; DuckDB secret reloads; cold reads work
 else

--- a/cmd/archiver/main.go
+++ b/cmd/archiver/main.go
@@ -397,6 +397,14 @@ type archiveCycle struct {
 	iceTable         string
 	now              time.Time
 	debugExportDelay time.Duration
+	// The archive watermark as it stood when this cycle's tiering pass began,
+	// captured by bootstrapTieredView before the per-partition loop and held
+	// fixed for the whole pass. Each cutover advances the stored watermark to
+	// its own partition's upper bound, so this snapshot is what keeps
+	// "already archived" a property of the cycle rather than of a partition's
+	// position in the loop.
+	wmCutoff time.Time
+	haveWM   bool
 }
 
 // runCycle performs one archive pass for a single table: ensures future
@@ -577,16 +585,14 @@ func (ac *archiveCycle) tierExpiredPartitions(ctx context.Context, hotExpired []
 	return nil
 }
 
-// archiveOnePartition tiers one past-hot partition: if the watermark is already
-// past its upper bound it was archived in a prior cycle, so just detach + drop
-// (idempotent cleanup, no race); otherwise run the full archive pipeline.
+// archiveOnePartition tiers one past-hot partition: if the cycle-start
+// watermark was already past its upper bound it was archived in a prior cycle,
+// so just clean up the stale PG partition; otherwise run the full archive
+// pipeline. Candidates arrive in ascending bound order, so within one cycle a
+// partition is only ever reached before the watermark passes its range.
 func (ac *archiveCycle) archiveOnePartition(ctx context.Context, part partition.Info, columns []view.Column) error {
 	t := ac.t
-	wmCutoff, found, err := ac.wmStore.Get(ctx, t.SourceSchema, t.SourceTable)
-	if err != nil {
-		return fmt.Errorf("get watermark: %w", err)
-	}
-	if found && !part.UpperBound.After(wmCutoff) {
+	if ac.haveWM && !part.UpperBound.After(ac.wmCutoff) {
 		return ac.cleanupAlreadyArchived(ctx, part)
 	}
 
@@ -604,10 +610,11 @@ func (ac *archiveCycle) archiveOnePartition(ctx context.Context, part partition.
 // per-partition / per-period loop, never inside it.
 func (ac *archiveCycle) bootstrapTieredView(ctx context.Context, columns []view.Column) error {
 	t, iceTable := ac.t, ac.iceTable
-	wmCutoff, _, err := ac.wmStore.Get(ctx, t.SourceSchema, t.SourceTable)
+	wmCutoff, found, err := ac.wmStore.Get(ctx, t.SourceSchema, t.SourceTable)
 	if err != nil {
 		return fmt.Errorf("get watermark: %w", err)
 	}
+	ac.wmCutoff, ac.haveWM = wmCutoff, found // the cycle-start snapshot; see archiveCycle
 	bootstrapCfg := view.ViewConfig{
 		SourceSchema:    t.SourceSchema,
 		SourceTable:     t.SourceTable,
@@ -627,13 +634,30 @@ func (ac *archiveCycle) bootstrapTieredView(ctx context.Context, columns []view.
 	return nil
 }
 
-// cleanupAlreadyArchived is the idempotent cleanup branch: the partition was
-// archived in a prior cycle (watermark already past its upper bound), so there
-// is no race — just detach + drop the stale PG partition.
+// cleanupAlreadyArchived removes a stale PG partition whose range the cold
+// tier already covers. The drop requires direct evidence that nothing is lost:
+// the partition must be empty. That is the legitimate case, an operator
+// creating a historical partition over a range that has already been tiered.
+//
+// A partition below the watermark that still holds rows is an anomaly. Phase 4
+// detaches atomically with the watermark advance, so a partition the pipeline
+// archived is never a candidate again, and rows here are in neither tier: an
+// out-of-band write straight to the heap, or a mesh peer writing hot against a
+// stale cutoff. They are the only copy, so the table fails loudly.
 func (ac *archiveCycle) cleanupAlreadyArchived(ctx context.Context, part partition.Info) error {
 	t, partMgr := ac.t, ac.partMgr
-	log.Printf("partition %s already archived, cleaning up", part.Name)
-	parent := partition.ResolveSourceTable(ctx, ac.conn, t.SourceSchema, t.SourceTable)
+	rows, err := partMgr.RowCount(ctx, t.SourceSchema, part.Name)
+	if err != nil {
+		return fmt.Errorf("count rows in %s before dropping it: %w", part.Name, err)
+	}
+	if rows > 0 {
+		return fmt.Errorf("refusing to drop %s.%s: its range is already below the archive "+
+			"watermark, yet it holds %d row(s) that were never exported to the cold tier. "+
+			"Move them into the cold tier (or out of the database) and drop the partition, "+
+			"then re-run", t.SourceSchema, part.Name, rows)
+	}
+	log.Printf("partition %s is empty and its range is already cold, dropping it", part.Name)
+	parent := partMgr.ResolveSourceTable(ctx, t.SourceSchema, t.SourceTable)
 	if err := partMgr.Detach(ctx, parent, t.SourceSchema, part.Name); err != nil {
 		return fmt.Errorf("detach %s: %w", part.Name, err)
 	}

--- a/cmd/archiver/main_test.go
+++ b/cmd/archiver/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pgedge/coldfront/internal/config"
+	"github.com/pgedge/coldfront/internal/partition"
 	"github.com/pgedge/coldfront/internal/view"
 )
 
@@ -495,6 +496,65 @@ func TestCutoverFailHint(t *testing.T) {
 	assert.Contains(t, h, "must be dropped", "gives actionable guidance")
 	assert.Empty(t, cutoverFailHint(&pgconn.PgError{Code: "55P03"}), "no hint for the transient lock timeout")
 	assert.Empty(t, cutoverFailHint(errors.New("boom")), "no hint for non-Postgres errors")
+}
+
+// cleanupCycle builds an archiveCycle whose partition Manager is backed by a
+// mock answering the three reads the cleanup path makes: the partition's row
+// count, the hot-table name resolution, and the Spock probe (no peers). onExec
+// receives every statement the path executes.
+func cleanupCycle(rowCount int64, onExec func(sql string)) *archiveCycle {
+	db := &mockQuerier{
+		rowFunc: func(_ context.Context, sql string, _ ...any) pgx.Row {
+			return &mockRow{scanFunc: func(dest ...any) error {
+				switch {
+				case strings.Contains(sql, "count(*)"):
+					*(dest[0].(*int64)) = rowCount
+				case strings.Contains(sql, "pg_extension"):
+					*(dest[0].(*bool)) = false // vanilla: no Spock, no peer fan-out
+				default:
+					*(dest[0].(*bool)) = true // hot table already swapped to _sales
+				}
+				return nil
+			}}
+		},
+		execFunc: func(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+			onExec(sql)
+			return pgconn.NewCommandTag("OK"), nil
+		},
+	}
+	return &archiveCycle{
+		t:       &config.TableConfig{SourceSchema: "public", SourceTable: "sales"},
+		partMgr: partition.NewManager(db),
+	}
+}
+
+// A partition whose range sits below the watermark but which still holds rows
+// is an anomaly, not a cleanup candidate: the pipeline detaches atomically with
+// the watermark advance, so an archived partition is never a candidate again.
+// Its rows are in neither tier, so they are the only copy and the drop is
+// refused.
+func TestCleanupAlreadyArchived_RefusesNonEmptyPartition(t *testing.T) {
+	ac := cleanupCycle(70, func(sql string) {
+		t.Fatalf("nothing may be executed for a partition holding rows, got: %s", sql)
+	})
+	err := ac.cleanupAlreadyArchived(context.Background(),
+		partition.Info{Name: "sales_p_2025_9"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sales_p_2025_9")
+	assert.Contains(t, err.Error(), "70")
+}
+
+// The legitimate case: an empty partition over a range the cold tier already
+// holds (an operator-created historical partition). Nothing can be lost, so it
+// is detached and dropped.
+func TestCleanupAlreadyArchived_DropsEmptyPartition(t *testing.T) {
+	var executed []string
+	ac := cleanupCycle(0, func(sql string) { executed = append(executed, sql) })
+	require.NoError(t, ac.cleanupAlreadyArchived(context.Background(),
+		partition.Info{Name: "sales_p_2025_9"}))
+	ran := strings.Join(executed, "\n")
+	assert.Contains(t, ran, "DETACH PARTITION", "an empty stale partition is detached")
+	assert.Contains(t, ran, "DROP TABLE", "an empty stale partition is dropped")
 }
 
 // Two tables sharing a name in different PG schemas map to distinct Iceberg

--- a/docs/architecture_tiered.md
+++ b/docs/architecture_tiered.md
@@ -127,7 +127,23 @@ when the extension is not loaded.
 
 ### The archive pipeline
 
-Each partition past the hot window then moves to Iceberg through a
+Candidates are tiered oldest first, ordered by partition **bound**. The order
+is a correctness contract: each cutover advances the watermark to its
+partition's upper bound, so chronological order is what guarantees every
+partition is exported while the watermark still sits below its range. A
+partition's place in time is its range; the name is a label the user chose and
+is free to sort against the calendar.
+
+A partition already below the watermark when the cycle begins was tiered by an
+earlier cycle, leaving only its stale PostgreSQL partition to remove. That
+drop requires the partition to be **empty**. Phase 4 detaches atomically with
+the watermark advance, so a partition the pipeline archived is never a
+candidate again, and rows found in one here are in neither tier: an
+out-of-band write to the heap, or a mesh peer writing hot against a stale
+cutoff. Those rows are the only copy, so the archiver refuses the drop and
+fails the table.
+
+Each remaining partition past the hot window then moves to Iceberg through a
 six-phase pipeline:
 
 **0. Idempotent Iceberg-range wipe** - deletes any Iceberg rows already

--- a/internal/partition/partition.go
+++ b/internal/partition/partition.go
@@ -3,6 +3,7 @@ package partition
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -260,10 +261,10 @@ func (m *Manager) EnsureCurrent(ctx context.Context, parent, schema, period stri
 func (m *Manager) createPartition(ctx context.Context, parent, schema, period string, d time.Time, b Boundary, leafPrefix string) error {
 	lower, upper := PartitionBounds(d, period)
 	// Table-scope the leaf name. The date suffix alone (p_2026_06) is not unique
-	// within a schema, so two flat tables in the same schema would generate the
-	// SAME partition name and the second's CREATE … IF NOT EXISTS would silently
-	// no-op (issue #11). Prefixing with the parent table makes every leaf unique
-	// per schema — the same scheme the 2-level path already uses (child_p_2026_06).
+	// within a schema, so two flat tables in one schema generate the SAME
+	// partition name and the second's CREATE … IF NOT EXISTS silently no-ops.
+	// Prefixing with the parent table makes every leaf unique per schema, the
+	// same scheme the 2-level path uses (child_p_2026_06).
 	// The leading "_" of a tiered hot table is stripped so the prefix is STABLE
 	// across the archiver's events→_events rename: premake (pre-swap, parent
 	// "events") and a later run (post-swap, parent "_events") must produce the
@@ -284,11 +285,11 @@ func (m *Manager) createPartition(ctx context.Context, parent, schema, period st
 	if _, err := m.db.Exec(ctx, sql); err != nil { // nosemgrep
 		return fmt.Errorf("create partition %s: %w", name, err)
 	}
-	// CREATE … IF NOT EXISTS no-ops if a relation with this name already exists —
+	// CREATE … IF NOT EXISTS no-ops if a relation with this name already exists,
 	// even one attached to a DIFFERENT parent (a name collision, or identifier
 	// truncation). Verify the partition is actually attached to OUR parent, so a
-	// collision fails loud instead of silently leaving the table partition-less
-	// and the run reporting success (issue #11, bug 2).
+	// collision fails loud instead of leaving the table partition-less while the
+	// run reports success.
 	var attached bool
 	if err := m.db.QueryRow(ctx, /* nosemgrep */
 		`SELECT EXISTS(SELECT 1 FROM pg_inherits WHERE inhrelid = to_regclass($1) AND inhparent = to_regclass($2))`,
@@ -317,7 +318,18 @@ func (m *Manager) FindExpired(ctx context.Context, parent, schema string, cutoff
 }
 
 // listPartitions enumerates every direct partition of parent with its bounds
-// decoded to time via the Boundary. Shared by FindExpired and EnsureCurrent.
+// decoded to time via the Boundary, in ascending bound order. Shared by
+// FindExpired and EnsureCurrent.
+//
+// The order comes from the bounds. A partition's place in time is its range;
+// the name is a label the caller chose, free to sort against the calendar
+// (unpadded month numbers, where "10" precedes "9" as text; month
+// abbreviations; an open MINVALUE edge). Callers that walk the result in order
+// depend on it being chronological: the archiver tiers candidates in this
+// order and advances the watermark to each upper bound in turn, so every
+// partition is reached while the watermark still sits below its range. The SQL
+// order only makes the fetch deterministic; the stable sort below establishes
+// the contract.
 func (m *Manager) listPartitions(ctx context.Context, parent, schema string, b Boundary) ([]Info, error) {
 	const query = `
 		SELECT c.relname, pg_get_expr(c.relpartbound, c.oid)
@@ -346,7 +358,14 @@ func (m *Manager) listPartitions(ctx context.Context, parent, schema string, b B
 		}
 		parts = append(parts, Info{Name: name, LowerBound: lower, UpperBound: upper})
 	}
-	return parts, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// One parent's ranges are disjoint, so the lower bound totally orders them.
+	sort.SliceStable(parts, func(i, j int) bool {
+		return parts[i].LowerBound.Before(parts[j].LowerBound)
+	})
+	return parts, nil
 }
 
 // Detach detaches a partition from its parent concurrently. CONCURRENTLY avoids

--- a/internal/partition/partition_test.go
+++ b/internal/partition/partition_test.go
@@ -26,6 +26,7 @@ type mockRows struct {
 	rows   []func(dest ...any) error
 	idx    int
 	closed bool
+	err    error // reported by Err(), as pgx does for a mid-iteration failure
 }
 
 func (r *mockRows) Next() bool {
@@ -39,7 +40,7 @@ func (r *mockRows) Scan(dest ...any) error {
 }
 
 func (r *mockRows) Close()                                       { r.closed = true }
-func (r *mockRows) Err() error                                   { return nil }
+func (r *mockRows) Err() error                                   { return r.err }
 func (r *mockRows) CommandTag() pgconn.CommandTag                { return pgconn.NewCommandTag("SELECT") }
 func (r *mockRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
 func (r *mockRows) RawValues() [][]byte                          { return nil }
@@ -351,6 +352,66 @@ func TestFindExpired(t *testing.T) {
 	assert.Equal(t, "p_2025_11", parts[0].Name)
 	assert.Equal(t, time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC), parts[0].UpperBound)
 	assert.Equal(t, "p_2025_12", parts[1].Name)
+}
+
+// TestFindExpired_OrdersByBoundNotName locks the ordering contract: candidates
+// come back in ascending bound order whatever the partitions are named. A
+// partition's place in time is its bound; the name is a label the user chose,
+// and unpadded month numbers ("10" < "9" as text) are the everyday case where
+// the two disagree. The archiver tiers candidates in this order and advances
+// the watermark to each upper bound in turn, so chronological order is what
+// keeps every partition exported before its range goes cold.
+func TestFindExpired_OrdersByBoundNotName(t *testing.T) {
+	db := &mockDB{rowsFunc: partitionRows(
+		[2]string{"sales_p_2025_10", "FOR VALUES FROM ('2025-10-01 00:00:00+00') TO ('2025-11-01 00:00:00+00')"},
+		[2]string{"sales_p_2025_9", "FOR VALUES FROM ('2025-09-01 00:00:00+00') TO ('2025-10-01 00:00:00+00')"},
+	)}
+	cutoff := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	parts, err := NewManager(db).FindExpired(context.Background(), "sales", "public", cutoff, TimeBoundary{})
+	require.NoError(t, err)
+	require.Len(t, parts, 2)
+	assert.Equal(t, "sales_p_2025_9", parts[0].Name, "September is first by bound, last by name")
+	assert.Equal(t, "sales_p_2025_10", parts[1].Name)
+}
+
+// TestFindExpired_PropagatesRowError locks that a failure part-way through
+// iteration reaches the caller instead of a short candidate list. The archiver
+// drops every partition it is handed once the export succeeds, so a silently
+// truncated list is as dangerous as a mis-ordered one.
+func TestFindExpired_PropagatesRowError(t *testing.T) {
+	boom := errors.New("connection reset mid-iteration")
+	db := &mockDB{rowsFunc: func(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+		return &mockRows{
+			rows: []func(dest ...any) error{
+				func(dest ...any) error {
+					*(dest[0].(*string)) = "sales_p_9"
+					*(dest[1].(*string)) = "FOR VALUES FROM ('2025-09-01 00:00:00+00') TO ('2025-10-01 00:00:00+00')"
+					return nil
+				},
+			},
+			err: boom,
+		}, nil
+	}}
+	cutoff := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	parts, err := NewManager(db).FindExpired(context.Background(), "sales", "public", cutoff, TimeBoundary{})
+	require.ErrorIs(t, err, boom)
+	assert.Nil(t, parts, "a truncated candidate list must never reach the caller")
+}
+
+// TestFindExpired_OrdersOpenLowerBoundFirst covers the same contract for an
+// unbounded lower edge: MINVALUE parses to a sentinel below every real bound,
+// so the open partition sorts first even though its name sorts last.
+func TestFindExpired_OrdersOpenLowerBoundFirst(t *testing.T) {
+	db := &mockDB{rowsFunc: partitionRows(
+		[2]string{"events_bc", "FOR VALUES FROM ('0100-01-01 BC') TO ('0043-01-01 BC')"},
+		[2]string{"events_open_lo", "FOR VALUES FROM (MINVALUE) TO ('0100-01-01 BC')"},
+	)}
+	cutoff := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	parts, err := NewManager(db).FindExpired(context.Background(), "events", "public", cutoff, TimeBoundary{})
+	require.NoError(t, err)
+	require.Len(t, parts, 2)
+	assert.Equal(t, "events_open_lo", parts[0].Name, "the open lower edge precedes every real bound")
+	assert.Equal(t, "events_bc", parts[1].Name)
 }
 
 // TestEnsureFuture_SnowflakeBounds locks that an id-mode (snowflake) premake


### PR DESCRIPTION
Partitions past the hot window were tiered in name order while the
destructive branch compared bounds. With any naming whose text order differs
from calendar order (unpadded months, where "10" sorts before "9"), the first
cutover carried the watermark past a later partition, which was then dropped
as already-archived without ever being exported: rows in neither tier, exit 0.

Candidates now sort by bound. The watermark is read once per cycle instead of
once per partition, so loop order cannot change a partition's outcome.
Dropping a stale partition requires it to be empty rather than relying on the
watermark alone.

The two-level path was unaffected: it already grouped leaves by upper bound
and never consulted the watermark.

Closes #71
