### PR TITLE
pg_duckdb: drop build-id links so per-major packages coinstall

### DIFF
--- a/packaging/coldfront-duckdb-extensions/rpm/coldfront-duckdb-extensions.spec
+++ b/packaging/coldfront-duckdb-extensions/rpm/coldfront-duckdb-extensions.spec
@@ -66,5 +66,5 @@ install -D -m 0644 %{sname}-sbom.json.asc %{buildroot}%{_datadir}/pgedge-%{sname
 %{_datadir}/pgedge-%{sname}/%{sname}-sbom.json.asc
 
 %changelog
-* Tue Jul 01 2026 Muhammad Aqeel <muhammad.aqeel@pgedge.com> - 1.5.4-1
+* Wed Jul 01 2026 Muhammad Aqeel <muhammad.aqeel@pgedge.com> - 1.5.4-1
 - Initial build of the ColdFront patched DuckDB extensions (DuckDB 1.5.4)

--- a/packaging/coldfront/rpm/coldfront.spec
+++ b/packaging/coldfront/rpm/coldfront.spec
@@ -58,5 +58,5 @@ install -p -m 0644 %{_builddir}/%{sname}-%{version}/%{sname}-sbom.json.asc %{bui
 %{pginstdir}/sbom/%{sname}-sbom.json.asc
 
 %changelog
-* Mon Jun 30 2026 Muhammad Aqeel <muhammad.aqeel@pgedge.com> - 1.0.0-1
+* Tue Jun 30 2026 Muhammad Aqeel <muhammad.aqeel@pgedge.com> - 1.0.0-1
 - Initial build of the pgEdge ColdFront extension

--- a/packaging/pg_duckdb/deb/debian/rules
+++ b/packaging/pg_duckdb/deb/debian/rules
@@ -20,6 +20,9 @@ override_dh_auto_test:
 	# pg_duckdb's `make check` drives a full regression harness that needs a
 	# running server and is not packaging-relevant; skip it during the build.
 
+override_dh_strip:
+	dh_strip --no-automatic-dbgsym
+
 override_dh_dwz:
 	# libduckdb.so is enormous; dwz bails with "Too many DIEs" and errors out.
 	# Skip dwz debug-info optimization (not packaging-relevant).

--- a/packaging/pg_duckdb/rpm/pg_duckdb.spec
+++ b/packaging/pg_duckdb/rpm/pg_duckdb.spec
@@ -110,5 +110,5 @@ install -p -m 0644 %{_builddir}/%{sname}-%{version}/%{sname}-sbom.json.asc %{bui
 %{pginstdir}/sbom/%{sname}-sbom.json.asc
 
 %changelog
-* Mon Jun 30 2026 Muhammad Aqeel <muhammad.aqeel@pgedge.com> - 1.5.4-1
+* Tue Jun 30 2026 Muhammad Aqeel <muhammad.aqeel@pgedge.com> - 1.5.4-1
 - ColdFront build of pgEdge pg_duckdb (DuckDB 1.5.4, pg_duckdb PR #1025)

--- a/packaging/pg_duckdb/rpm/pg_duckdb.spec
+++ b/packaging/pg_duckdb/rpm/pg_duckdb.spec
@@ -4,6 +4,8 @@
 # installed artifacts (pg_duckdb.so, pg_duckdb.control, tarball dir).
 %global pkgname pg-duckdb
 
+%global _build_id_links none
+
 Name:		pgedge-%{pkgname}_%{pgmajorversion}
 Version:	%{pg_duckdb_version}
 Release:	%{pg_duckdb_buildnum}%{?dist}


### PR DESCRIPTION
## Summary

  The bundled `libduckdb.so` is PG-major independent, so every per-major build produced it identically — same bytes, same build-id. Each package then claimed the same `/usr/lib/.build-id/<xx>/<hash>`, and the three majors refused to install side
  by side:

  file /usr/lib/.build-id/67/521b25... conflicts between attempted installs of
  pgedge-pg-duckdb_16 and pgedge-pg-duckdb_18

  The debuginfo packages collided on the same hash, and dpkg hit it too — dbgsym packages are build-id addressed by construction.

  **RPM** (`%global _build_id_links none`): drops the build-id entries from the main *and* debuginfo packages. Debug files remain, addressed by path (`/usr/lib/debug/usr/pgsql-NN/…`), which differs per major, so nothing overlaps. `debug_package`
  is deliberately left enabled — disabling it also disables the strip that produces debuginfo, which would leave DuckDB's full DWARF (~212 MB, measured on el10) inside each main package.

  **DEB** (`dh_strip --no-automatic-dbgsym`): dbgsym has no equivalent knob, so the packages simply aren't produced. This does give up debug symbols on Debian, for `pg_duckdb.so` as well as the engine.

  Verified in containers with the real spec and `debian/rules`
