### PR TITLE
docs: make the SECURITY.md links clickable

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,9 @@
 
 ## Reporting a Vulnerability
 
-Please report security vulnerabilities to **security@pgedge.com**, which
-reaches the pgEdge security team.
+Please report security vulnerabilities to
+[**security@pgedge.com**](mailto:security@pgedge.com), which reaches the
+pgEdge security team.
 
 Please do not open a public issue for a suspected vulnerability.
 
@@ -25,7 +26,7 @@ What is in scope, our safe harbour terms, and how we handle coordinated
 disclosure and CVE identifiers are all set out in the pgEdge Vulnerability
 Disclosure Statement:
 
-**https://docs.pgedge.com/security**
+[**https://docs.pgedge.com/security**](https://docs.pgedge.com/security)
 
 You may test this software freely in an environment you control. Testing
 pgEdge Cloud requires prior written authorisation — see the statement.


### PR DESCRIPTION
Follow-up to #80, which merged before Dave's review landed on `pgEdge/pgedge-safesession#73`.

That review asked for the statement URL to be a real link rather than bare text:

> This should be a clickable link (Github may render it as such, but other viewers may not)

GitHub autolinks a bare URL, but nothing guarantees another viewer will, and the two actionable things in a security policy should not depend on a renderer. So both are now explicit Markdown links:

- `https://docs.pgedge.com/security` — the disclosure statement
- `security@pgedge.com` — the reporting address, now a `mailto:` link

The address was not part of Dave's comment, but it is the same defect, and the published statement at <https://docs.pgedge.com/security> already writes it as an explicit `mailto:` link. This keeps the two documents consistent.

The file stays byte-identical to the block in the approved template and to the copy going into every other pgEdge repo, so there is nothing coldfront-specific here.